### PR TITLE
feat: 회원 가입 시 닉네임 중복 예외처리, 이메일 인증 주소 예외처리, 프로필 수정 api

### DIFF
--- a/src/main/java/gang/GNUtingBackend/exception/handler/MailHandler.java
+++ b/src/main/java/gang/GNUtingBackend/exception/handler/MailHandler.java
@@ -1,0 +1,11 @@
+package gang.GNUtingBackend.exception.handler;
+
+import gang.GNUtingBackend.exception.GeneralException;
+import gang.GNUtingBackend.response.code.BaseErrorCode;
+
+public class MailHandler extends GeneralException {
+
+    public MailHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/gang/GNUtingBackend/mail/service/MailService.java
+++ b/src/main/java/gang/GNUtingBackend/mail/service/MailService.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service;
 public class MailService {
 
     private final JavaMailSender javaMailSender;
-    private static final String senderEmail = "gentleman959@gmail.com";
+    private static final String senderEmail = "gnuting@gnuting.com";
     private static int number;
 
     public static void createNumber() {
@@ -56,5 +56,9 @@ public class MailService {
         MimeMessage message = CreateMail(email);
         javaMailSender.send(message);
         return number;
+    }
+
+    public boolean isValidAddress(String email) {
+        return email.endsWith("@gnu.ac.kr");
     }
 }

--- a/src/main/java/gang/GNUtingBackend/mail/service/MailService.java
+++ b/src/main/java/gang/GNUtingBackend/mail/service/MailService.java
@@ -1,5 +1,7 @@
 package gang.GNUtingBackend.mail.service;
 
+import gang.GNUtingBackend.exception.handler.MailHandler;
+import gang.GNUtingBackend.response.code.status.ErrorStatus;
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
@@ -51,8 +53,10 @@ public class MailService {
         return message;
     }
 
-    public int sendMail(String email){
-
+    public int sendMail(String email) {
+        if (!isValidAddress(email)) {
+            throw new MailHandler(ErrorStatus.INVALID_MAIL_ADDRESS);
+        }
         MimeMessage message = CreateMail(email);
         javaMailSender.send(message);
         return number;

--- a/src/main/java/gang/GNUtingBackend/response/ApiResponse.java
+++ b/src/main/java/gang/GNUtingBackend/response/ApiResponse.java
@@ -26,6 +26,11 @@ public class ApiResponse<T> {
         return new ApiResponse<>(true, SuccessStatus.SUCCESS.getCode() , SuccessStatus.SUCCESS.getMessage(), result);
     }
 
+    // 성공한 경우 응답 생성
+    public static <T> ApiResponse<T> onSuccess(T result, String message) {
+        return new ApiResponse<>(true, SuccessStatus.SUCCESS.getCode(), message, result);
+    }
+
     public static <T> ApiResponse<T> of(BaseCode code, T result){
         return new ApiResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), result);
     }

--- a/src/main/java/gang/GNUtingBackend/response/code/status/ErrorStatus.java
+++ b/src/main/java/gang/GNUtingBackend/response/code/status/ErrorStatus.java
@@ -21,9 +21,10 @@ public enum ErrorStatus implements BaseErrorCode {
     NICKNAME_INPUT_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER4002", "닉네임을 입력해주세요"),
     DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "USER4003", "이미 사용중인 닉네임입니다."),
     USER_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "USER4004", "이미 가입된 사용자입니다."),
-    PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "USER4005", "비밀번호가 일치하지 않습니다.");
+    PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "USER4005", "비밀번호가 일치하지 않습니다."),
 
-    // Board 관련 에러
+    // 메일 관련 에러
+    INVALID_MAIL_ADDRESS(HttpStatus.BAD_REQUEST, "MAIL4001", "경상국립대학교 이메일을 입력해주세요.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/gang/GNUtingBackend/user/controller/UserController.java
+++ b/src/main/java/gang/GNUtingBackend/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package gang.GNUtingBackend.user.controller;
 
+import gang.GNUtingBackend.exception.handler.UserHandler;
 import gang.GNUtingBackend.image.service.ImageService;
 import gang.GNUtingBackend.response.ApiResponse;
 import gang.GNUtingBackend.response.code.status.ErrorStatus;
@@ -104,17 +105,12 @@ public class UserController {
     @GetMapping("/check-nickname")
     public ResponseEntity<ApiResponse<Boolean>> checkNicknameAvailability(@RequestParam("nickname") String nickname) {
         boolean isAvailable = userService.isNicknameAvailable(nickname);
-        ApiResponse<Boolean> apiResponse;
 
-        if (isAvailable) {
-            apiResponse = ApiResponse.onSuccess(isAvailable, "사용 가능한 닉네임입니다.");
-        } else {
-            apiResponse = ApiResponse.onFailure(ErrorStatus.DUPLICATE_NICKNAME.getCode(),
-                    ErrorStatus.DUPLICATE_NICKNAME.getMessage(), isAvailable);
+        if (!isAvailable) {
+            throw new UserHandler(ErrorStatus.DUPLICATE_NICKNAME);
         }
-
-        return ResponseEntity.ok()
-                .body(apiResponse);
+        ApiResponse<Boolean> apiResponse = ApiResponse.onSuccess(true, "사용 가능한 닉네임입니다.");
+        return ResponseEntity.ok().body(apiResponse);
     }
 
 }

--- a/src/main/java/gang/GNUtingBackend/user/controller/UserController.java
+++ b/src/main/java/gang/GNUtingBackend/user/controller/UserController.java
@@ -6,6 +6,7 @@ import gang.GNUtingBackend.response.ApiResponse;
 import gang.GNUtingBackend.response.code.status.ErrorStatus;
 import gang.GNUtingBackend.user.domain.enums.Gender;
 import gang.GNUtingBackend.user.domain.enums.UserRole;
+import gang.GNUtingBackend.user.dto.UserDetailResponseDto;
 import gang.GNUtingBackend.user.dto.UserLoginRequestDto;
 import gang.GNUtingBackend.user.dto.UserLoginResponseDto;
 import gang.GNUtingBackend.user.dto.UserSignupRequestDto;
@@ -19,8 +20,10 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -37,13 +40,16 @@ public class UserController {
 
     /**
      * 사용자 로그인 요청을 처리하고, 로그인이 성공했을 때 응답 헤더에 토큰을 추가하여 반환한다.
+     *
      * @param userLoginRequestDto
      * @return
      */
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<UserLoginResponseDto>> login(@RequestBody UserLoginRequestDto userLoginRequestDto) {
+    public ResponseEntity<ApiResponse<UserLoginResponseDto>> login(
+            @RequestBody UserLoginRequestDto userLoginRequestDto) {
         HttpHeaders httpHeaders = new HttpHeaders();
-        UserLoginResponseDto userLoginResponseDto = userService.login(userLoginRequestDto.getEmail(), userLoginRequestDto.getPassword());
+        UserLoginResponseDto userLoginResponseDto = userService.login(userLoginRequestDto.getEmail(),
+                userLoginRequestDto.getPassword());
         String token = tokenProvider.createToken(userLoginResponseDto.getEmail(), userLoginResponseDto.getUserRole());
 
         httpHeaders.add("Authorization", "Bearer " + token);
@@ -57,6 +63,7 @@ public class UserController {
 
     /**
      * 사용자의 가입 요청을 처리하고, 가입이 성공했을 때, 응답 헤더에 토큰을 추가하여 반환한다.
+     *
      * @param
      * @return
      */
@@ -73,7 +80,7 @@ public class UserController {
             @RequestParam("studentId") String studentId,
             @RequestParam(value = "profileImage", required = false) MultipartFile profileImage,
             @RequestParam("userSelfIntroduction") String userSelfIntroduction
-            ) throws IOException {
+    ) throws IOException {
 
         String mediaLink = null;
         if (profileImage != null && !profileImage.isEmpty()) {
@@ -99,6 +106,7 @@ public class UserController {
 
     /**
      * 닉네임이 사용가능한지의 여부를 반환한다.
+     *
      * @param nickname
      * @return
      */
@@ -113,4 +121,26 @@ public class UserController {
         return ResponseEntity.ok().body(apiResponse);
     }
 
+    @PatchMapping("/update")
+    public ResponseEntity<ApiResponse<UserDetailResponseDto>> userInfoUpdate(
+            @RequestHeader("Authorization") String token,
+            @RequestParam(value = "profileImage", required = false) MultipartFile profileImage,
+            @RequestParam("nickname") String nickname,
+            @RequestParam("password") String password,
+            @RequestParam("department") String department,
+            @RequestParam("userSelfIntroduction") String userSelfIntroduction) throws IOException {
+        token = token.substring(7);
+        String email = tokenProvider.getUserEmail(token);
+
+        String mediaLink = null;
+        if (profileImage != null && !profileImage.isEmpty()) {
+            mediaLink = imageService.uploadProfileImage(profileImage, email);
+        }
+
+        ApiResponse<UserDetailResponseDto> apiResponse = ApiResponse.onSuccess(userService.userInfoUpdate(mediaLink, nickname, password, department, userSelfIntroduction, token));
+
+        return ResponseEntity.ok()
+                .body(apiResponse);
+    }
 }
+

--- a/src/main/java/gang/GNUtingBackend/user/controller/UserController.java
+++ b/src/main/java/gang/GNUtingBackend/user/controller/UserController.java
@@ -2,6 +2,7 @@ package gang.GNUtingBackend.user.controller;
 
 import gang.GNUtingBackend.image.service.ImageService;
 import gang.GNUtingBackend.response.ApiResponse;
+import gang.GNUtingBackend.response.code.status.ErrorStatus;
 import gang.GNUtingBackend.user.domain.enums.Gender;
 import gang.GNUtingBackend.user.domain.enums.UserRole;
 import gang.GNUtingBackend.user.dto.UserLoginRequestDto;
@@ -16,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -94,19 +96,25 @@ public class UserController {
                 .body(apiResponse);
     }
 
-//    @PostMapping("/signup")
-//    public ResponseEntity<ApiResponse<UserSignupResponseDto>> signup(@RequestBody UserSignupRequestDto userSignupRequestDto) {
-//        HttpHeaders httpHeaders = new HttpHeaders();
-//        UserSignupResponseDto user = userService.signup(userSignupRequestDto);
-//        String token = tokenProvider.createToken(user.getEmail(), user.getUserRole());
-//
-//        httpHeaders.add("Authorization", "Bearer " + token);
-//
-//        ApiResponse<UserSignupResponseDto> apiResponse = ApiResponse.onSuccess(user);
-//
-//        return ResponseEntity.ok()
-//                .headers(httpHeaders)
-//                .body(apiResponse);
-//    }
+    /**
+     * 닉네임이 사용가능한지의 여부를 반환한다.
+     * @param nickname
+     * @return
+     */
+    @GetMapping("/check-nickname")
+    public ResponseEntity<ApiResponse<Boolean>> checkNicknameAvailability(@RequestParam("nickname") String nickname) {
+        boolean isAvailable = userService.isNicknameAvailable(nickname);
+        ApiResponse<Boolean> apiResponse;
+
+        if (isAvailable) {
+            apiResponse = ApiResponse.onSuccess(isAvailable, "사용 가능한 닉네임입니다.");
+        } else {
+            apiResponse = ApiResponse.onFailure(ErrorStatus.DUPLICATE_NICKNAME.getCode(),
+                    ErrorStatus.DUPLICATE_NICKNAME.getMessage(), isAvailable);
+        }
+
+        return ResponseEntity.ok()
+                .body(apiResponse);
+    }
 
 }

--- a/src/main/java/gang/GNUtingBackend/user/domain/User.java
+++ b/src/main/java/gang/GNUtingBackend/user/domain/User.java
@@ -74,11 +74,11 @@ public class User extends BaseEntity {
     // 사용자 한줄 소개
     private String userSelfIntroduction;
 
-    public void update(UserUpdateRequestDto userUpdateRequestDto) {
-        this.profileImage = userUpdateRequestDto.getProfileImage();
-        this.nickname = userUpdateRequestDto.getNickname();
-        this.password = userUpdateRequestDto.getPassword();
-        this.department = userUpdateRequestDto.getDepartment();
-        this.userSelfIntroduction = userUpdateRequestDto.getUserSelfIntroduction();
+    public void update(String profileImage, String nickname, String password, String department, String userSelfIntroduction) {
+        this.profileImage = profileImage;
+        this.nickname = nickname;
+        this.password = password;
+        this.department = department;
+        this.userSelfIntroduction = userSelfIntroduction;
     }
 }

--- a/src/main/java/gang/GNUtingBackend/user/domain/User.java
+++ b/src/main/java/gang/GNUtingBackend/user/domain/User.java
@@ -2,6 +2,7 @@ package gang.GNUtingBackend.user.domain;
 
 import gang.GNUtingBackend.user.domain.enums.Gender;
 import gang.GNUtingBackend.user.domain.enums.UserRole;
+import gang.GNUtingBackend.user.dto.UserUpdateRequestDto;
 import java.time.LocalDate;
 import javax.persistence.*;
 
@@ -72,4 +73,12 @@ public class User extends BaseEntity {
 
     // 사용자 한줄 소개
     private String userSelfIntroduction;
+
+    public void update(UserUpdateRequestDto userUpdateRequestDto) {
+        this.profileImage = userUpdateRequestDto.getProfileImage();
+        this.nickname = userUpdateRequestDto.getNickname();
+        this.password = userUpdateRequestDto.getPassword();
+        this.department = userUpdateRequestDto.getDepartment();
+        this.userSelfIntroduction = userUpdateRequestDto.getUserSelfIntroduction();
+    }
 }

--- a/src/main/java/gang/GNUtingBackend/user/dto/UserUpdateRequestDto.java
+++ b/src/main/java/gang/GNUtingBackend/user/dto/UserUpdateRequestDto.java
@@ -4,7 +4,6 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @AllArgsConstructor
@@ -16,4 +15,8 @@ public class UserUpdateRequestDto {
     private String password;
     private String department;
     private String userSelfIntroduction;
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
 }

--- a/src/main/java/gang/GNUtingBackend/user/dto/UserUpdateRequestDto.java
+++ b/src/main/java/gang/GNUtingBackend/user/dto/UserUpdateRequestDto.java
@@ -1,0 +1,19 @@
+package gang.GNUtingBackend.user.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserUpdateRequestDto {
+
+    private String profileImage;
+    private String nickname;
+    private String password;
+    private String department;
+    private String userSelfIntroduction;
+}

--- a/src/main/java/gang/GNUtingBackend/user/repository/UserRepository.java
+++ b/src/main/java/gang/GNUtingBackend/user/repository/UserRepository.java
@@ -18,4 +18,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("select u from User u where u.gender = :gender and u.nickname = :nickname")
     User findByUserSearch(Gender gender,String nickname);
+
+    /**
+     * 닉네임을 통해 해당 닉네임을 가진 User를 찾는다.
+     * @param nickname
+     * @return
+     */
+    Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/gang/GNUtingBackend/user/service/UserService.java
+++ b/src/main/java/gang/GNUtingBackend/user/service/UserService.java
@@ -138,7 +138,7 @@ public class UserService {
      * @return UserDetailResponseDto
      */
     @Transactional
-    public UserDetailResponseDto InfoUpdate(UserUpdateRequestDto userUpdateRequestDto, String token) {
+    public UserDetailResponseDto userInfoUpdate(UserUpdateRequestDto userUpdateRequestDto, String token) {
         String email = tokenProvider.getUserEmail(token);
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));

--- a/src/main/java/gang/GNUtingBackend/user/service/UserService.java
+++ b/src/main/java/gang/GNUtingBackend/user/service/UserService.java
@@ -117,4 +117,14 @@ public class UserService {
                 .userSelfIntroduction(user.getUserSelfIntroduction())
                 .build();
     }
+
+    /**
+     * 닉네임이 사용가능한지 여부를 판단한다.
+     * @param nickname
+     * @return 닉네임이 사용가능하면 true, 사용 불가능하면 false
+     */
+    @Transactional(readOnly = true)
+    public boolean isNicknameAvailable(String nickname) {
+        return userRepository.findByNickname(nickname).isEmpty();
+    }
 }

--- a/src/main/java/gang/GNUtingBackend/user/service/UserService.java
+++ b/src/main/java/gang/GNUtingBackend/user/service/UserService.java
@@ -133,20 +133,23 @@ public class UserService {
 
     /**
      * 사용자의 정보를 업데이트 한다.
-     * @param userUpdateRequestDto 사용자 업데이트 정보
-     * @param token 토큰
-     * @return UserDetailResponseDto
+     * @param profileImage
+     * @param nickname
+     * @param password
+     * @param department
+     * @param userSelfIntroduction
+     * @param token
+     * @return
      */
     @Transactional
-    public UserDetailResponseDto userInfoUpdate(UserUpdateRequestDto userUpdateRequestDto, String token) {
+    public UserDetailResponseDto userInfoUpdate(String profileImage, String nickname, String password, String department, String userSelfIntroduction, String token) {
         String email = tokenProvider.getUserEmail(token);
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
-        String encodedPassword = bCryptPasswordEncoder.encode(userUpdateRequestDto.getPassword());
-        userUpdateRequestDto.setPassword(encodedPassword);
+        String encodedPassword = bCryptPasswordEncoder.encode(password);
 
-        user.update(userUpdateRequestDto);
+        user.update(profileImage, nickname, encodedPassword, department, userSelfIntroduction);
 
         return UserDetailResponseDto.builder()
                 .id(user.getId())


### PR DESCRIPTION
- 회원 가입 시 이미 사용하고 있는 닉네임인지 확인하는 api를 구현하였습니다.

- 이메일 인증시, @gnu.ac.kr 이메일로 인증 메일이 보내지도록 이메일 주소를 확인하는 api를 구현하였습니다.

- 프로필 사진, 닉네임, 비밀번호, 학과, 한줄 소개를 수정하는 프로필 수정 api를 구현하였습니다.