### PR TITLE
feat: Querydsl을 활용하여 게시글 제목, 학과를 입력하면 사용자와 성별이 다른 사용자가 쓴 게시글을 검색하는 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,14 @@
+buildscript {
+	ext {
+		queryDslVersion = "5.0.0"
+	}
+}
+
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '2.7.17'
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+	id 'com.ewerk.gradle.plugins.querydsl' version "1.0.10"
 }
 
 group = 'gang'
@@ -53,6 +60,34 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
 	implementation group: 'com.google.firebase', name: 'firebase-admin', version: '8.0.1'
+
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+	implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
+
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+	jpa = true
+	querydslSourcesDir = querydslDir
+}
+sourceSets {
+	main.java.srcDir querydslDir
+}
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+	querydsl.extendsFrom compileClasspath
+}
+compileQuerydsl {
+	options.annotationProcessorPath = configurations.querydsl
+}
+
+compileQuerydsl.doFirst {
+	if(file(querydslDir).exists() )
+		delete(file(querydslDir))
 }
 
 tasks.named('test') {

--- a/src/main/java/gang/GNUtingBackend/GnUtingBackendApplication.java
+++ b/src/main/java/gang/GNUtingBackend/GnUtingBackendApplication.java
@@ -1,7 +1,10 @@
 package gang.GNUtingBackend;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import javax.persistence.EntityManager;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 
@@ -18,5 +21,10 @@ public class GnUtingBackendApplication {
 //	public TestData testData(BoardRepository boardRepository, UserRepository userRepository){
 //		return new TestData(boardRepository,userRepository);
 //	}
+
+	@Bean
+	JPAQueryFactory jpaQueryFactory(EntityManager em) {
+		return new JPAQueryFactory(em);
+	}
 
 }

--- a/src/main/java/gang/GNUtingBackend/board/controller/BoardController.java
+++ b/src/main/java/gang/GNUtingBackend/board/controller/BoardController.java
@@ -2,6 +2,7 @@ package gang.GNUtingBackend.board.controller;
 
 import gang.GNUtingBackend.board.dto.BoardRequestDto;
 import gang.GNUtingBackend.board.dto.BoardResponseDto;
+import gang.GNUtingBackend.board.dto.BoardSearchResultDto;
 import gang.GNUtingBackend.board.dto.BoardShowAllResponseDto;
 import gang.GNUtingBackend.board.service.BoardService;
 import gang.GNUtingBackend.board.entity.Board;
@@ -96,6 +97,21 @@ public class BoardController {
         String saved = boardService.apply(id, userSearchRequestDto, email);
         return ResponseEntity.ok()
                 .body(ApiResponse.onSuccess(saved));
+    }
+
+    @GetMapping("/board/search")
+    public ResponseEntity<?> searchBoards (
+            @RequestParam("keyword") String keyword,
+            @RequestHeader("Authorization") String token,
+            Pageable pageable
+    ) {
+        String email = tokenProvider.getUserEmail(token.substring(7));
+
+        Page<BoardSearchResultDto> boardSearchResultDtos = boardService.searchBoards(keyword, email, pageable);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.onSuccess(boardSearchResultDtos));
+
     }
 }
 

--- a/src/main/java/gang/GNUtingBackend/board/dto/BoardSearchResultDto.java
+++ b/src/main/java/gang/GNUtingBackend/board/dto/BoardSearchResultDto.java
@@ -1,0 +1,22 @@
+package gang.GNUtingBackend.board.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardSearchResultDto {
+
+    private Long BoardId;
+
+    // 게시글 제목
+    private String title;
+
+    // 작성자 학과
+    private String department;
+
+    // 작성자 학번
+    private String studentId;
+}

--- a/src/main/java/gang/GNUtingBackend/board/dto/BoardSearchResultDto.java
+++ b/src/main/java/gang/GNUtingBackend/board/dto/BoardSearchResultDto.java
@@ -1,15 +1,15 @@
 package gang.GNUtingBackend.board.dto;
 
+import java.awt.image.TileObserver;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
-@AllArgsConstructor
 public class BoardSearchResultDto {
 
-    private Long BoardId;
+    private Long boardId;
 
     // 게시글 제목
     private String title;
@@ -19,4 +19,11 @@ public class BoardSearchResultDto {
 
     // 작성자 학번
     private String studentId;
+
+    public BoardSearchResultDto(Long boardId, String title, String department, String studentId) {
+        this.boardId = boardId;
+        this.title = title;
+        this.department = department;
+        this.studentId = studentId.substring(2, 4) + "학번";
+    }
 }

--- a/src/main/java/gang/GNUtingBackend/board/entity/ApplyUsers.java
+++ b/src/main/java/gang/GNUtingBackend/board/entity/ApplyUsers.java
@@ -27,6 +27,4 @@ public class ApplyUsers {
     @JoinColumn(name = "user_id")
     private User userId;
 
-
-
 }

--- a/src/main/java/gang/GNUtingBackend/board/entity/Board.java
+++ b/src/main/java/gang/GNUtingBackend/board/entity/Board.java
@@ -48,6 +48,4 @@ public class Board extends BaseTime {
     @OneToMany(mappedBy = "boardId",cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<BoardApplyLeader> boardApplyLeader;
 
-
-
 }

--- a/src/main/java/gang/GNUtingBackend/board/repository/SearchBoardRepository.java
+++ b/src/main/java/gang/GNUtingBackend/board/repository/SearchBoardRepository.java
@@ -1,2 +1,11 @@
-package gang.GNUtingBackend.board.repository;public class SearchBoardRepository {
+package gang.GNUtingBackend.board.repository;
+
+import gang.GNUtingBackend.board.dto.BoardSearchResultDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface SearchBoardRepository {
+
+    Page<BoardSearchResultDto> searchByTitleOrDepartment(String keyWord, String email, Pageable pageable);
+
 }

--- a/src/main/java/gang/GNUtingBackend/board/repository/SearchBoardRepository.java
+++ b/src/main/java/gang/GNUtingBackend/board/repository/SearchBoardRepository.java
@@ -1,0 +1,2 @@
+package gang.GNUtingBackend.board.repository;public class SearchBoardRepository {
+}

--- a/src/main/java/gang/GNUtingBackend/board/repository/SearchBoardRepositoryImpl.java
+++ b/src/main/java/gang/GNUtingBackend/board/repository/SearchBoardRepositoryImpl.java
@@ -1,0 +1,2 @@
+package gang.GNUtingBackend.board.repository;public class SearchBoardRepositoryImpl {
+}

--- a/src/main/java/gang/GNUtingBackend/board/repository/SearchBoardRepositoryImpl.java
+++ b/src/main/java/gang/GNUtingBackend/board/repository/SearchBoardRepositoryImpl.java
@@ -1,2 +1,68 @@
-package gang.GNUtingBackend.board.repository;public class SearchBoardRepositoryImpl {
+package gang.GNUtingBackend.board.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import gang.GNUtingBackend.board.dto.BoardSearchResultDto;
+import gang.GNUtingBackend.board.entity.QBoard;
+import gang.GNUtingBackend.user.domain.QUser;
+import gang.GNUtingBackend.user.domain.enums.Gender;
+import java.util.List;
+import javax.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class SearchBoardRepositoryImpl implements SearchBoardRepository{
+
+    private final EntityManager em;
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<BoardSearchResultDto> searchByTitleOrDepartment(String keyword, String email, Pageable pageable) {
+
+        QBoard qBoard = QBoard.board;
+        QUser qUser = QUser.user;
+
+        Gender userGender = getUserGenderByEmail(email);
+
+        List<BoardSearchResultDto> results = jpaQueryFactory
+                .select(Projections.constructor(BoardSearchResultDto.class,
+                        qBoard.id,
+                        qBoard.title,
+                        qUser.department,
+                        qUser.studentId))
+                .from(qBoard)
+                .join(qBoard.userId, qUser)
+                .where(qBoard.title.contains(keyword)
+                        .or(qUser.department.contains(keyword))
+                        .and(qBoard.gender.ne(userGender)))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = jpaQueryFactory
+                .selectFrom(qBoard)
+                .join(qBoard.userId, qUser)
+                .where(qBoard.title.contains(keyword)
+                        .or(qUser.department.contains(keyword))
+                        .and(qBoard.gender.ne(userGender)))
+                .fetchCount();
+
+        return new PageImpl<>(results, pageable, total);
+    }
+
+    private Gender getUserGenderByEmail(String userEmail) {
+        QUser qUser = QUser.user;
+        Gender gender = jpaQueryFactory
+                .select(qUser.gender)
+                .from(qUser)
+                .where(qUser.email.eq(userEmail))
+                .fetchOne();
+        return gender == Gender.MALE ? Gender.MALE : Gender.FEMALE;
+    }
+
 }

--- a/src/main/java/gang/GNUtingBackend/board/service/BoardService.java
+++ b/src/main/java/gang/GNUtingBackend/board/service/BoardService.java
@@ -11,6 +11,7 @@ import gang.GNUtingBackend.board.repository.BoardApplyLeaderRepository;
 import gang.GNUtingBackend.board.repository.BoardRepository;
 import gang.GNUtingBackend.board.repository.BoardParticipantRepository;
 import gang.GNUtingBackend.board.entity.Board;
+import gang.GNUtingBackend.board.repository.SearchBoardRepositoryImpl;
 import gang.GNUtingBackend.exception.UserAlreadyException;
 import gang.GNUtingBackend.exception.handler.BoardHandler;
 import gang.GNUtingBackend.exception.handler.UserHandler;
@@ -43,6 +44,7 @@ public class BoardService {
     private final UserRepository userRepository;
     private final BoardApplyLeaderRepository boardApplyLeaderRepository;
     private final ApplyUsersRepository applyUsersRepository;
+    private final SearchBoardRepositoryImpl searchBoardRepository;
 
     /**
      * 게시글 모두 보기
@@ -282,5 +284,9 @@ public class BoardService {
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
         return UserSearchResponseDto.toDto(user);
 
+    }
+
+    public Page<BoardSearchResultDto> searchBoards(String keyword, String email, Pageable pageable) {
+        return searchBoardRepository.searchByTitleOrDepartment(keyword, email, pageable);
     }
 }

--- a/src/main/java/gang/GNUtingBackend/department/domain/Department.java
+++ b/src/main/java/gang/GNUtingBackend/department/domain/Department.java
@@ -22,6 +22,7 @@ public class Department {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    // 학과 이름
     @Column(nullable = false)
     private String name;
 }


### PR DESCRIPTION
### 게시판 글 검색 API

- Querydsl을 활용하여 게시글 제목, 학과를 입력하여 해당 게시글을 조회할 수 있도록 하였습니다.

- 사용자와 성별이 다른 사용자가 쓴 게시글만 조회됩니다 ex) 남성 사용자는 여성 사용자의 게시글만, 여성 사용자는 남성 사용자의 게시글만 조회됩니다.

