### PR TITLE
feat: redis를 이용하여 refreshToken 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,8 @@ dependencies {
 	implementation("com.slack.api:bolt-jetty:1.18.0")
 
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
+
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 def querydslDir = "$buildDir/generated/querydsl"

--- a/src/main/java/gang/GNUtingBackend/board/controller/BoardController.java
+++ b/src/main/java/gang/GNUtingBackend/board/controller/BoardController.java
@@ -5,20 +5,15 @@ import gang.GNUtingBackend.board.dto.BoardResponseDto;
 import gang.GNUtingBackend.board.dto.BoardSearchResultDto;
 import gang.GNUtingBackend.board.dto.BoardShowAllResponseDto;
 import gang.GNUtingBackend.board.service.BoardService;
-import gang.GNUtingBackend.board.entity.Board;
-
 import gang.GNUtingBackend.response.ApiResponse;
-import gang.GNUtingBackend.user.dto.UserSearchRequestDto;
 import gang.GNUtingBackend.user.dto.UserSearchResponseDto;
 import gang.GNUtingBackend.user.token.TokenProvider;
-import io.opencensus.metrics.export.Summary;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/gang/GNUtingBackend/config/redis/RedisConfig.java
+++ b/src/main/java/gang/GNUtingBackend/config/redis/RedisConfig.java
@@ -1,0 +1,37 @@
+package gang.GNUtingBackend.config.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(redisHost, redisPort));
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return redisTemplate;
+    }
+}
+

--- a/src/main/java/gang/GNUtingBackend/exception/handler/TokenHandler.java
+++ b/src/main/java/gang/GNUtingBackend/exception/handler/TokenHandler.java
@@ -1,0 +1,11 @@
+package gang.GNUtingBackend.exception.handler;
+
+import gang.GNUtingBackend.exception.GeneralException;
+import gang.GNUtingBackend.response.code.BaseErrorCode;
+
+public class TokenHandler extends GeneralException {
+
+    public TokenHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/gang/GNUtingBackend/response/code/status/ErrorStatus.java
+++ b/src/main/java/gang/GNUtingBackend/response/code/status/ErrorStatus.java
@@ -46,7 +46,8 @@ public enum ErrorStatus implements BaseErrorCode {
     EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001", "Access Token이 만료되었습니다."),
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001", "유효하지 않은 Access Token입니다."),
     EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001", "Refresh Token이 만료되었습니다."),
-    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001", "유효하지 않은 Refresh Token입니다.");
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001", "유효하지 않은 Refresh Token입니다."),
+    NOT_EXPIRED_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "TOKEN4000", "만료되지 않은 Access 토큰입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/gang/GNUtingBackend/response/code/status/ErrorStatus.java
+++ b/src/main/java/gang/GNUtingBackend/response/code/status/ErrorStatus.java
@@ -40,8 +40,13 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_MAIL_ADDRESS(HttpStatus.BAD_REQUEST, "MAIL4001", "경상국립대학교 이메일을 입력해주세요."),
 
     // slack 관련 에러
-    CANNOT_SEND_MESSAGE(HttpStatus.INTERNAL_SERVER_ERROR, "SLACK5001", "slack으로 메세지를 보내지 못하였습니다.");
+    CANNOT_SEND_MESSAGE(HttpStatus.INTERNAL_SERVER_ERROR, "SLACK5001", "slack으로 메세지를 보내지 못하였습니다."),
 
+    // token 관련 에러
+    EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001", "Access Token이 만료되었습니다."),
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001", "유효하지 않은 Access Token입니다."),
+    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001", "Refresh Token이 만료되었습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001", "유효하지 않은 Refresh Token입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/gang/GNUtingBackend/response/code/status/ErrorStatus.java
+++ b/src/main/java/gang/GNUtingBackend/response/code/status/ErrorStatus.java
@@ -47,7 +47,10 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001", "유효하지 않은 Access Token입니다."),
     EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001", "Refresh Token이 만료되었습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001", "유효하지 않은 Refresh Token입니다."),
-    NOT_EXPIRED_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "TOKEN4000", "만료되지 않은 Access 토큰입니다.");
+    NOT_EXPIRED_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "TOKEN4000", "만료되지 않은 Access 토큰입니다."),
+    INVALID_JWT_SIGNATURE(HttpStatus.UNAUTHORIZED, "TOKEN4001", "잘못된 JWT 서명입니다."),
+    UNSUPPORTED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001", "지원되지 않는 JWT 토큰입니다."),
+    INVALID_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001", "JWT 토큰이 잘못되었습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/gang/GNUtingBackend/user/controller/UserController.java
+++ b/src/main/java/gang/GNUtingBackend/user/controller/UserController.java
@@ -24,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -44,7 +45,7 @@ public class UserController {
     private final ImageService imageService;
 
     /**
-     * 사용자 로그인 요청을 처리하고, 로그인이 성공했을 때 응답 헤더에 토큰을 추가하여 반환한다.
+     * 사용자 로그인 요청을 처리하고, 로그인이 성공했을 때 토큰을 반환한다.
      *
      * @param userLoginRequestDto
      * @return
@@ -63,7 +64,7 @@ public class UserController {
     }
 
     /**
-     * 사용자의 가입 요청을 처리하고, 가입이 성공했을 때, 응답 헤더에 토큰을 추가하여 반환한다.
+     * 사용자의 가입 요청을 처리하고, 가입이 성공했을 때, 토큰을 반환한다.
      *
      * @param
      * @return
@@ -163,6 +164,33 @@ public class UserController {
 
         return ResponseEntity.ok()
                 .body(apiResponse);
+    }
+
+    /**
+     * 로그아웃 API
+     * @param refreshToken 로그아웃 요청에 사용된 리프레시 토큰
+     * @return 로그아웃 성공 메시지
+     */
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃 API", description = "사용자 로그아웃을 처리합니다.")
+    public ResponseEntity<ApiResponse<String>> logout(@RequestBody String refreshToken) {
+        userService.logout(refreshToken);
+        return ResponseEntity.ok()
+                .body(ApiResponse.onSuccess("정상적으로 로그아웃 처리 되었습니다."));
+    }
+
+    /**
+     * 회원 탈퇴 API
+     * @param token 회원 탈퇴 요청에 사용된 액세스 토큰
+     * @return 회원 탈퇴 성공 메시지
+     */
+    @DeleteMapping("/deleteUser")
+    @Operation(summary = "회원 탈퇴 API", description = "사용자 회원 탈퇴를 처리합니다.")
+    public ResponseEntity<ApiResponse<String>> deleteUser(@RequestHeader("Authorization") String token) {
+        String email = tokenProvider.getUserEmail(token.substring(7));
+        userService.deleteUser(email);
+        return ResponseEntity.ok()
+                .body(ApiResponse.onSuccess("정상적으로 회원 탈퇴 되었습니다."));
     }
 }
 

--- a/src/main/java/gang/GNUtingBackend/user/controller/UserController.java
+++ b/src/main/java/gang/GNUtingBackend/user/controller/UserController.java
@@ -11,6 +11,8 @@ import gang.GNUtingBackend.user.dto.UserLoginRequestDto;
 import gang.GNUtingBackend.user.dto.UserLoginResponseDto;
 import gang.GNUtingBackend.user.dto.UserSignupRequestDto;
 import gang.GNUtingBackend.user.dto.UserSignupResponseDto;
+import gang.GNUtingBackend.user.dto.token.ReIssueTokenRequestDto;
+import gang.GNUtingBackend.user.dto.token.ReIssueTokenResponseDto;
 import gang.GNUtingBackend.user.dto.token.TokenResponseDto;
 import gang.GNUtingBackend.user.service.UserService;
 import gang.GNUtingBackend.user.token.TokenProvider;
@@ -151,6 +153,18 @@ public class UserController {
         }
 
         ApiResponse<UserDetailResponseDto> apiResponse = ApiResponse.onSuccess(userService.userInfoUpdate(mediaLink, nickname, password, department, userSelfIntroduction, token));
+
+        return ResponseEntity.ok()
+                .body(apiResponse);
+    }
+
+    @PostMapping("/reIssueAccessToken")
+    @Operation(summary = "토큰 재발급 API", description = "refresh 토큰으로 accessToken을 재발급합니다.")
+    public ResponseEntity<ApiResponse<ReIssueTokenResponseDto>> reIssueAccessToken(@RequestBody ReIssueTokenRequestDto reIssueTokenRequestDto) {
+        ReIssueTokenResponseDto response = userService.reissueAccessToken(
+                reIssueTokenRequestDto.getRefreshToken());
+
+        ApiResponse<ReIssueTokenResponseDto> apiResponse = ApiResponse.onSuccess(response);
 
         return ResponseEntity.ok()
                 .body(apiResponse);

--- a/src/main/java/gang/GNUtingBackend/user/controller/UserController.java
+++ b/src/main/java/gang/GNUtingBackend/user/controller/UserController.java
@@ -70,7 +70,7 @@ public class UserController {
      */
     @PostMapping("/signup")
     @Operation(summary = "회원가입 API", description = "사용자의 정보를 바탕으로 회원가입을 진행합니다.")
-    public ResponseEntity<ApiResponse<UserSignupResponseDto>> signup(
+    public ResponseEntity<ApiResponse<TokenResponseDto>> signup(
             @RequestParam("email") @Parameter(description = "경상국립대학교 이메일") String email,
             @RequestParam("password") @Parameter(description = "비밀번호") String password,
             @RequestParam("name") @Parameter(description = "이름") String name,
@@ -93,16 +93,11 @@ public class UserController {
                 email, password, name, phoneNumber, gender, birthDate, nickname, department, studentId, mediaLink,
                 UserRole.ROLE_USER, userSelfIntroduction);
 
-        HttpHeaders httpHeaders = new HttpHeaders();
-        UserSignupResponseDto user = userService.signup(userSignupRequestDto);
-        String token = tokenProvider.createToken(user.getEmail(), user.getUserRole());
+        TokenResponseDto response = userService.signup(userSignupRequestDto);
 
-        httpHeaders.add("Authorization", "Bearer " + token);
-
-        ApiResponse<UserSignupResponseDto> apiResponse = ApiResponse.onSuccess(user);
+        ApiResponse<TokenResponseDto> apiResponse = ApiResponse.onSuccess(response);
 
         return ResponseEntity.ok()
-                .headers(httpHeaders)
                 .body(apiResponse);
     }
 

--- a/src/main/java/gang/GNUtingBackend/user/controller/UserController.java
+++ b/src/main/java/gang/GNUtingBackend/user/controller/UserController.java
@@ -11,17 +11,16 @@ import gang.GNUtingBackend.user.dto.UserLoginRequestDto;
 import gang.GNUtingBackend.user.dto.UserLoginResponseDto;
 import gang.GNUtingBackend.user.dto.UserSignupRequestDto;
 import gang.GNUtingBackend.user.dto.UserSignupResponseDto;
+import gang.GNUtingBackend.user.dto.token.TokenResponseDto;
 import gang.GNUtingBackend.user.service.UserService;
 import gang.GNUtingBackend.user.token.TokenProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
 import java.io.IOException;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -50,19 +49,14 @@ public class UserController {
      */
     @PostMapping("/login")
     @Operation(summary = "로그인 API", description = "이메일과 비밀번호를 사용하여 로그인합니다.")
-    public ResponseEntity<ApiResponse<UserLoginResponseDto>> login(
+    public ResponseEntity<ApiResponse<TokenResponseDto>> login(
             @RequestBody UserLoginRequestDto userLoginRequestDto) {
-        HttpHeaders httpHeaders = new HttpHeaders();
-        UserLoginResponseDto userLoginResponseDto = userService.login(userLoginRequestDto.getEmail(),
+        TokenResponseDto response = userService.login(userLoginRequestDto.getEmail(),
                 userLoginRequestDto.getPassword());
-        String token = tokenProvider.createToken(userLoginResponseDto.getEmail(), userLoginResponseDto.getUserRole());
 
-        httpHeaders.add("Authorization", "Bearer " + token);
-
-        ApiResponse<UserLoginResponseDto> apiResponse = ApiResponse.onSuccess(userLoginResponseDto);
+        ApiResponse<TokenResponseDto> apiResponse = ApiResponse.onSuccess(response);
 
         return ResponseEntity.ok()
-                .headers(httpHeaders)
                 .body(apiResponse);
     }
 

--- a/src/main/java/gang/GNUtingBackend/user/domain/Token.java
+++ b/src/main/java/gang/GNUtingBackend/user/domain/Token.java
@@ -1,5 +1,6 @@
 package gang.GNUtingBackend.user.domain;
 
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import javax.persistence.Id;
 import lombok.AllArgsConstructor;
@@ -24,5 +25,8 @@ public class Token {
     @TimeToLive(unit = TimeUnit.MILLISECONDS)
     private long expiration;
 
+    public static String createRefreshToken() {
+        return UUID.randomUUID().toString();
+    }
 
 }

--- a/src/main/java/gang/GNUtingBackend/user/domain/Token.java
+++ b/src/main/java/gang/GNUtingBackend/user/domain/Token.java
@@ -1,0 +1,28 @@
+package gang.GNUtingBackend.user.domain;
+
+import java.util.concurrent.TimeUnit;
+import javax.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.redis.core.TimeToLive;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Token {
+
+    @Id
+    private Long id;
+
+    private String refreshToken;
+
+    private String accessToken;
+
+    @TimeToLive(unit = TimeUnit.MILLISECONDS)
+    private long expiration;
+
+
+}

--- a/src/main/java/gang/GNUtingBackend/user/domain/Token.java
+++ b/src/main/java/gang/GNUtingBackend/user/domain/Token.java
@@ -15,7 +15,7 @@ import org.springframework.data.redis.core.TimeToLive;
 public class Token {
 
     @Id
-    private Long id;
+    private String email;
 
     private String refreshToken;
 

--- a/src/main/java/gang/GNUtingBackend/user/domain/Token.java
+++ b/src/main/java/gang/GNUtingBackend/user/domain/Token.java
@@ -29,4 +29,8 @@ public class Token {
         return UUID.randomUUID().toString();
     }
 
+    public void setAccessToken(String newAccessToken) {
+        this.accessToken = newAccessToken;
+    }
+
 }

--- a/src/main/java/gang/GNUtingBackend/user/dto/token/ReIssueTokenRequestDto.java
+++ b/src/main/java/gang/GNUtingBackend/user/dto/token/ReIssueTokenRequestDto.java
@@ -1,0 +1,14 @@
+package gang.GNUtingBackend.user.dto.token;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReIssueTokenRequestDto {
+
+    private String refreshToken;
+}

--- a/src/main/java/gang/GNUtingBackend/user/dto/token/ReIssueTokenResponseDto.java
+++ b/src/main/java/gang/GNUtingBackend/user/dto/token/ReIssueTokenResponseDto.java
@@ -1,0 +1,11 @@
+package gang.GNUtingBackend.user.dto.token;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+public class ReIssueTokenResponseDto {
+    String accessToken;
+}

--- a/src/main/java/gang/GNUtingBackend/user/dto/token/TokenResponseDto.java
+++ b/src/main/java/gang/GNUtingBackend/user/dto/token/TokenResponseDto.java
@@ -1,0 +1,14 @@
+package gang.GNUtingBackend.user.dto.token;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenResponseDto {
+
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/gang/GNUtingBackend/user/service/UserService.java
+++ b/src/main/java/gang/GNUtingBackend/user/service/UserService.java
@@ -189,4 +189,27 @@ public class UserService {
         }
         throw new TokenHandler(ErrorStatus.NOT_EXPIRED_ACCESS_TOKEN);
     }
+
+    /**
+     * 로그아웃 로직
+     * @param refreshToken 로그아웃 요청한 사용자의 리프레시 토큰
+     */
+    @Transactional
+    public void logout(String refreshToken) {
+        refreshTokenService.logout(refreshToken);
+    }
+
+    /**
+     * 회원 탈퇴 로직
+     * @param email 탈퇴 요청한 사용자의 이메일
+     */
+    @Transactional
+    public void deleteUser(String email) {
+        // 사용자의 모든 리프레시 토큰 삭제
+        refreshTokenService.deleteUserRefreshTokens(email);
+        // 사용자 정보 삭제
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+        userRepository.delete(user);
+    }
 }

--- a/src/main/java/gang/GNUtingBackend/user/service/UserService.java
+++ b/src/main/java/gang/GNUtingBackend/user/service/UserService.java
@@ -182,7 +182,7 @@ public class UserService {
         return Token.createRefreshToken();
     }
 
-    private ReIssueTokenResponseDto reissueAccessToken(String refreshToken) {
+    public ReIssueTokenResponseDto reissueAccessToken(String refreshToken) {
         User user = refreshTokenService.getUserByRefreshToken(refreshToken);
         Token token = refreshTokenService.findTokenByRefreshToken(refreshToken);
         String oldAccessToken = token.getAccessToken();

--- a/src/main/java/gang/GNUtingBackend/user/token/RefreshTokenService.java
+++ b/src/main/java/gang/GNUtingBackend/user/token/RefreshTokenService.java
@@ -1,0 +1,54 @@
+package gang.GNUtingBackend.user.token;
+
+import gang.GNUtingBackend.exception.handler.TokenHandler;
+import gang.GNUtingBackend.exception.handler.UserHandler;
+import gang.GNUtingBackend.response.code.status.ErrorStatus;
+import gang.GNUtingBackend.user.domain.Token;
+import gang.GNUtingBackend.user.domain.User;
+import gang.GNUtingBackend.user.repository.UserRepository;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    // refreshToken 만료시간 (밀리초 단위)
+    // 14일 (2주)
+    private final long expiredDate = 60 * 60 * 1000 * 24 * 14;
+
+    private final UserRepository userRepository;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void saveToken(String email, String refreshToken, String accessToken) {
+        Token token = Token.builder()
+                .email(email)
+                .refreshToken(refreshToken)
+                .accessToken(accessToken)
+                .expiration(expiredDate)
+                .build();
+
+        redisTemplate.opsForValue().set(refreshToken, token, expiredDate, TimeUnit.MILLISECONDS);
+    }
+
+    public Token findTokenByRefreshToken(String refreshToken) {
+        Token token = (Token) redisTemplate.opsForValue().get(refreshToken);
+        if (token != null) {
+            return token;
+        }
+        throw new TokenHandler(ErrorStatus.INVALID_REFRESH_TOKEN);
+    }
+
+    public User getUserByRefreshToken(String refreshToken) {
+        Token token = findTokenByRefreshToken(refreshToken);
+        if (token.getExpiration() > 0) {
+            String email = token.getEmail();
+            return userRepository.findByEmail(email)
+                    .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+        }
+        throw new TokenHandler(ErrorStatus.INVALID_REFRESH_TOKEN);
+    }
+
+}

--- a/src/main/java/gang/GNUtingBackend/user/token/RefreshTokenService.java
+++ b/src/main/java/gang/GNUtingBackend/user/token/RefreshTokenService.java
@@ -6,6 +6,7 @@ import gang.GNUtingBackend.response.code.status.ErrorStatus;
 import gang.GNUtingBackend.user.domain.Token;
 import gang.GNUtingBackend.user.domain.User;
 import gang.GNUtingBackend.user.repository.UserRepository;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -53,6 +54,19 @@ public class RefreshTokenService {
 
     public void updateToken(Token token) {
         redisTemplate.opsForValue().set(token.getRefreshToken(), token, token.getExpiration(), TimeUnit.MILLISECONDS);
+    }
+
+    public void logout(String refreshToken) {
+        redisTemplate.delete(refreshToken);
+    }
+
+    public void deleteUserRefreshTokens(String email) {
+        // 사용자 이메일을 기반으로 저장된 모든 Refresh Token 키를 조회
+        Set<String> refreshTokens = redisTemplate.keys("*" + email + "*");
+        if (refreshTokens != null && !refreshTokens.isEmpty()) {
+            // 조회된 모든 Refresh Token 삭제
+            redisTemplate.delete(refreshTokens);
+        }
     }
 
 }

--- a/src/main/java/gang/GNUtingBackend/user/token/RefreshTokenService.java
+++ b/src/main/java/gang/GNUtingBackend/user/token/RefreshTokenService.java
@@ -51,4 +51,8 @@ public class RefreshTokenService {
         throw new TokenHandler(ErrorStatus.INVALID_REFRESH_TOKEN);
     }
 
+    public void updateToken(Token token) {
+        redisTemplate.opsForValue().set(token.getRefreshToken(), token, token.getExpiration(), TimeUnit.MILLISECONDS);
+    }
+
 }

--- a/src/main/java/gang/GNUtingBackend/user/token/TokenProvider.java
+++ b/src/main/java/gang/GNUtingBackend/user/token/TokenProvider.java
@@ -105,4 +105,13 @@ public class TokenProvider {
         }
         return false;
     }
+
+    public boolean isExpiredAccessToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+        } catch (ExpiredJwtException e) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/src/main/java/gang/GNUtingBackend/user/token/TokenProvider.java
+++ b/src/main/java/gang/GNUtingBackend/user/token/TokenProvider.java
@@ -1,5 +1,7 @@
 package gang.GNUtingBackend.user.token;
 
+import gang.GNUtingBackend.exception.handler.TokenHandler;
+import gang.GNUtingBackend.response.code.status.ErrorStatus;
 import gang.GNUtingBackend.user.domain.enums.UserRole;
 import gang.GNUtingBackend.user.auth.PrincipalDetails;
 import gang.GNUtingBackend.user.auth.PrincipalDetailsService;
@@ -95,15 +97,15 @@ public class TokenProvider {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
             return true;
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
-            log.info("잘못된 JWT 서명입니다.");
+            throw new TokenHandler(ErrorStatus.INVALID_ACCESS_TOKEN);
         } catch (ExpiredJwtException e) {
-            log.info("만료된 JWT 토큰입니다.");
+            throw new TokenHandler(ErrorStatus.EXPIRED_ACCESS_TOKEN);
         } catch (UnsupportedJwtException e) {
-            log.info("지원되지 않는 JWT 토큰입니다.");
+            throw new TokenHandler(ErrorStatus.UNSUPPORTED_JWT_TOKEN);
         } catch (IllegalArgumentException e) {
-            log.info("JWT 토큰이 잘못되었습니다.");
+            throw new TokenHandler(ErrorStatus.INVALID_JWT_TOKEN);
         }
-        return false;
+
     }
 
     public boolean isExpiredAccessToken(String token) {

--- a/src/main/java/gang/GNUtingBackend/user/token/TokenProvider.java
+++ b/src/main/java/gang/GNUtingBackend/user/token/TokenProvider.java
@@ -26,7 +26,7 @@ import org.springframework.stereotype.Component;
 public class TokenProvider {
 
     // 토큰 만료 시간 (밀리초 단위)
-    private final long expiredDate = 60 * 60 * 1000*24;
+    private final long expiredDate = 60 * 60 * 1000 * 24;
 
     private final PrincipalDetailsService principalDetailsService;
 

--- a/src/main/java/gang/GNUtingBackend/user/token/TokenProvider.java
+++ b/src/main/java/gang/GNUtingBackend/user/token/TokenProvider.java
@@ -26,6 +26,7 @@ import org.springframework.stereotype.Component;
 public class TokenProvider {
 
     // 토큰 만료 시간 (밀리초 단위)
+    // 24시간 (1일)
     private final long expiredDate = 60 * 60 * 1000 * 24;
 
     private final PrincipalDetailsService principalDetailsService;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,6 +47,10 @@ spring:
     project-id: charismatic-age-414606
     bucket: gnuting-develop-bucket
 
+  redis:
+    host: localhost
+    port: 6379
+
 app:
   firebase-configuration-file: ./charismatic-age-414606-08978a3bdbe0.json
   firebase-bucket: gnuting-develop-bucket


### PR DESCRIPTION
## redis를 이용하여 refreshToken 도입

- 기존 AccessToken만을 가지고 인증을 하던 방식에서 Access Token의 유효기간을 줄이고 유효기간이 긴 Refresh Token을 도입하여 클라이언트 측에서 Refresh Token의 유효기간이 만료되지 않는 이상 새 Access Token을 발급받아 사용자 인증이 가능하도록 하였습니다.

- Redis를 통해 사용자 accessToken, refreshToken 저장
- refreshToken을 통한 AccessToken 재발급
