### PR TITLE
refactor: slack token 환경변수 처리

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -79,7 +79,7 @@ jwt:
   duration: 30
 
 slack:
-  token: xoxb-6786312890577-6786320324161-scWVozk3T4MJn0Y68alXqw18
+  token: ${SLACK_TOKEN}
   channel:
     monitor: '#gnuting'
 


### PR DESCRIPTION
## slack token 환경변수 처리

- slack token이 외부에 유출 될시 자동으로 토큰이 만료되는데, 이를 막기 위해 환경변수로 처리하였습니다.