### PR TITLE
refactor: 환경변수 설정, 학번 형식, 닉네임 길이, 한 줄 소개 길이, 예외처리 구현

### DIFF
--- a/src/main/java/gang/GNUtingBackend/board/dto/BoardSearchResultDto.java
+++ b/src/main/java/gang/GNUtingBackend/board/dto/BoardSearchResultDto.java
@@ -24,6 +24,6 @@ public class BoardSearchResultDto {
         this.boardId = boardId;
         this.title = title;
         this.department = department;
-        this.studentId = studentId.substring(2, 4) + "학번";
+        this.studentId = studentId + "학번";
     }
 }

--- a/src/main/java/gang/GNUtingBackend/response/code/status/ErrorStatus.java
+++ b/src/main/java/gang/GNUtingBackend/response/code/status/ErrorStatus.java
@@ -17,12 +17,16 @@ public enum ErrorStatus implements BaseErrorCode {
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
     // User 관련 에러
-    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4001", "사용자가 없습니다."),
-    NICKNAME_INPUT_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER4002", "닉네임을 입력해주세요"),
-    DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "USER4003", "이미 사용중인 닉네임입니다."),
-    USER_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "USER4004", "이미 가입된 사용자입니다."),
-    PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "USER4005", "비밀번호가 일치하지 않습니다."),
-    USER_GENDER_NOT_MATCH(HttpStatus.BAD_REQUEST, "USER4001", "사용자가 없습니다. (성별이 일치하지않거나 닉네임이 잘못됐습니다.)"),
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4000", "사용자가 없습니다."),
+    NICKNAME_INPUT_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER4000", "닉네임을 입력해주세요"),
+    DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "USER4000", "이미 사용중인 닉네임입니다."),
+    USER_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "USER4000", "이미 가입된 사용자입니다."),
+    PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "USER4000", "비밀번호가 일치하지 않습니다."),
+    USER_GENDER_NOT_MATCH(HttpStatus.BAD_REQUEST, "USER4000", "사용자가 없습니다. (성별이 일치하지않거나 닉네임이 잘못됐습니다.)"),
+    INVALID_STUDENT_ID(HttpStatus.BAD_REQUEST, "USER4000", "학번은 숫자 2자리로 입력해주세요."),
+    NICKNAME_LENGTH_EXCEEDED(HttpStatus.BAD_REQUEST, "USER4000", "닉네임은 최대 10자까지 가능합니다."),
+    USER_SELF_INTRODUCTION_LENGTH_EXCEEDED(HttpStatus.BAD_REQUEST, "USER4000", "한 줄 소개는 최대 30자까지 가능합니다."),
+
     // Board 관련 에러
     BOARD_NOT_FOUND(HttpStatus.BAD_REQUEST,"BOARD5001", "게시글이 없습니다"),
     USER_NOT_FOUND_IN_BOARD(HttpStatus.BAD_REQUEST,"BOARD5002", "권한이없습니다.(게시글을 작성한 유저가 아닙니다)"),

--- a/src/main/java/gang/GNUtingBackend/user/controller/UserController.java
+++ b/src/main/java/gang/GNUtingBackend/user/controller/UserController.java
@@ -122,19 +122,17 @@ public class UserController {
      * @param token
      * @param profileImage
      * @param nickname
-     * @param password
      * @param department
      * @param userSelfIntroduction
      * @return
      * @throws IOException
      */
     @PatchMapping("/update")
-    @Operation(summary = "사용자 프로필 수정 API", description = "프로필 이미지, 닉네임, 비밀번호, 학과, 한 줄 소개를 수정합니다.")
+    @Operation(summary = "사용자 프로필 수정 API", description = "프로필 이미지, 닉네임, 학과, 한 줄 소개를 수정합니다.")
     public ResponseEntity<ApiResponse<UserDetailResponseDto>> userInfoUpdate(
             @RequestHeader("Authorization") String token,
             @RequestParam(value = "profileImage", required = false) @Parameter(description = "프로필 이미지") MultipartFile profileImage,
             @RequestParam("nickname") @Parameter(description = "닉네임") String nickname,
-            @RequestParam("password") @Parameter(description = "비밀번호") String password,
             @RequestParam("department") @Parameter(description = "학과") String department,
             @RequestParam("userSelfIntroduction") @Parameter(description = "한 줄 소개") String userSelfIntroduction) throws IOException {
         token = token.substring(7);
@@ -145,8 +143,8 @@ public class UserController {
             mediaLink = s3Uploader.uploadProfileImage(profileImage, email);
         }
 
-        ApiResponse<UserDetailResponseDto> apiResponse = ApiResponse.onSuccess(userService.userInfoUpdate(mediaLink, nickname, password, department, userSelfIntroduction, token));
 
+        ApiResponse<UserDetailResponseDto> apiResponse = ApiResponse.onSuccess(userService.userInfoUpdate(mediaLink, nickname, department, userSelfIntroduction, token));
         return ResponseEntity.ok()
                 .body(apiResponse);
     }

--- a/src/main/java/gang/GNUtingBackend/user/domain/User.java
+++ b/src/main/java/gang/GNUtingBackend/user/domain/User.java
@@ -6,6 +6,8 @@ import gang.GNUtingBackend.user.dto.UserUpdateRequestDto;
 import java.time.LocalDate;
 import javax.persistence.*;
 
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -52,7 +54,8 @@ public class User extends BaseEntity {
     private LocalDate birthDate;
 
     // 닉네임
-    @Column(nullable = false)
+    @Column(nullable = false, length = 10)
+    @Size(max = 10, message = "닉네임은 최대 10자까지 가능합니다.")
     private String nickname;
 
     // 학과
@@ -60,7 +63,8 @@ public class User extends BaseEntity {
     private String department;
 
     // 학번
-    @Column(nullable = false)
+    @Column(nullable = false, length = 4)
+    @Pattern(regexp = "^\\d{2}$", message = "학번은 2자리 숫자여야 합니다.")
     private String studentId;
 
     // 프로필 이미지
@@ -72,12 +76,13 @@ public class User extends BaseEntity {
     private UserRole userRole;
 
     // 사용자 한줄 소개
+    @Column(length = 30)
+    @Size(max = 30, message = "한 줄 소개는 최대 30자까지 가능합니다.")
     private String userSelfIntroduction;
 
-    public void update(String profileImage, String nickname, String password, String department, String userSelfIntroduction) {
+    public void update(String profileImage, String nickname, String department, String userSelfIntroduction) {
         this.profileImage = profileImage;
         this.nickname = nickname;
-        this.password = password;
         this.department = department;
         this.userSelfIntroduction = userSelfIntroduction;
     }

--- a/src/main/java/gang/GNUtingBackend/user/dto/UserSearchResponseDto.java
+++ b/src/main/java/gang/GNUtingBackend/user/dto/UserSearchResponseDto.java
@@ -34,7 +34,7 @@ public class UserSearchResponseDto {
                 .department(user.getDepartment())
                 .profileImage(user.getProfileImage())
                 .userRole(user.getUserRole())
-                .studentId(user.getStudentId().substring(2, 4) + "학번")
+                .studentId(user.getStudentId() + "학번")
                 .userSelfIntroduction(user.getUserSelfIntroduction())
                 .build();
     }

--- a/src/main/java/gang/GNUtingBackend/user/service/UserService.java
+++ b/src/main/java/gang/GNUtingBackend/user/service/UserService.java
@@ -164,7 +164,7 @@ public class UserService {
         }
 
         // 한 줄 소개 길이 검증
-        if (userSelfIntroduction.length() > 30) {
+        if (userSelfIntroduction != null && userSelfIntroduction.length() > 30) {
             throw new UserHandler(ErrorStatus.USER_SELF_INTRODUCTION_LENGTH_EXCEEDED);
         }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,8 +49,8 @@ spring:
       stack:
         auto: false
       credentials:
-        access-key: AKIA4B7AYCMQPHHTE7OW
-        secret-key: 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
+        access-key: ${S3_ACCESS_KEY}
+        secret-key: ${S3_SECRET_KEY}
 
   redis:
     host: localhost


### PR DESCRIPTION
## refactor: 환경변수 설정, 학번 형식, 닉네임 길이, 한 줄 소개 길이, 예외처리 구현

- application.yml에 slack token, S3 access-key, secret-key를 그대로 노출해서 깃에 올리게 되면 토큰이 자동으로 만료되어 사용하지 못하게 됩니다. 따라서 환경변수 설정을 하여 토큰을 안전하게 사용할 수 있도록 하였습니다.

- 학번 형식을 변경하였습니다. ex) 20, 21, 22

- 닉네임을 최대 10자까지 입력 받도록 하였습니다.

- 한 줄 소개는 최대 30자까지 가능하도로 하였습니다.

- 위의 조건들에 대한 예외처리를 구현하였습니다.
