### PR TITLE
feat: 이메일 인증번호 검증 API 구현, 로그아웃, 회원탈퇴, reissueAccessToken 리팩토링

### DIFF
--- a/src/main/java/gang/GNUtingBackend/board/entity/ApplyUsers.java
+++ b/src/main/java/gang/GNUtingBackend/board/entity/ApplyUsers.java
@@ -16,7 +16,7 @@ import javax.persistence.*;
 @Builder
 public class ApplyUsers {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/gang/GNUtingBackend/board/entity/Board.java
+++ b/src/main/java/gang/GNUtingBackend/board/entity/Board.java
@@ -33,6 +33,11 @@ public class Board extends BaseTime {
     @Column(nullable = false)
     private String detail;
 
+    /**
+     * 현재 글 상태
+     * OPEN - 아무나 이 글에 채팅 신청 가능한 상태
+     * CLOSE - 해당 글에 채팅방이 생성되어서 더 이상 채팅 신청이 불가능한 상태
+     */
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Status status;

--- a/src/main/java/gang/GNUtingBackend/board/entity/BoardApplyLeader.java
+++ b/src/main/java/gang/GNUtingBackend/board/entity/BoardApplyLeader.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class BoardApplyLeader {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/gang/GNUtingBackend/board/entity/BoardParticipant.java
+++ b/src/main/java/gang/GNUtingBackend/board/entity/BoardParticipant.java
@@ -15,7 +15,7 @@ import javax.persistence.*;
 @Builder
 public class BoardParticipant {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/gang/GNUtingBackend/board/entity/enums/Status.java
+++ b/src/main/java/gang/GNUtingBackend/board/entity/enums/Status.java
@@ -1,5 +1,10 @@
 package gang.GNUtingBackend.board.entity.enums;
 
+/**
+ * 현재 글 상태
+ * OPEN - 아무나 이 글에 채팅 신청 가능한 상태
+ * CLOSE - 해당 글에 채팅방이 생성되어서 더 이상 채팅 신청이 불가능한 상태
+ */
 public enum Status {
     OPEN,CLOSE
 }

--- a/src/main/java/gang/GNUtingBackend/board/service/BoardService.java
+++ b/src/main/java/gang/GNUtingBackend/board/service/BoardService.java
@@ -1,7 +1,6 @@
 package gang.GNUtingBackend.board.service;
 
 import gang.GNUtingBackend.board.dto.*;
-import gang.GNUtingBackend.board.entity.ApplyUsers;
 import gang.GNUtingBackend.board.entity.BoardApplyLeader;
 import gang.GNUtingBackend.board.entity.BoardParticipant;
 import gang.GNUtingBackend.board.entity.enums.ApplyStatus;
@@ -16,11 +15,9 @@ import gang.GNUtingBackend.exception.UserAlreadyException;
 import gang.GNUtingBackend.exception.handler.BoardHandler;
 import gang.GNUtingBackend.exception.handler.UserHandler;
 import gang.GNUtingBackend.notification.service.FCMService;
-import gang.GNUtingBackend.notification.service.UserNotificationService;
 import gang.GNUtingBackend.response.code.status.ErrorStatus;
 import gang.GNUtingBackend.user.domain.User;
 import gang.GNUtingBackend.user.domain.enums.Gender;
-import gang.GNUtingBackend.user.dto.UserSearchRequestDto;
 import gang.GNUtingBackend.user.dto.UserSearchResponseDto;
 import gang.GNUtingBackend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -30,13 +27,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import org.springframework.web.bind.annotation.RequestMapping;
 
 @Service
 @RequiredArgsConstructor
@@ -104,7 +98,7 @@ public class BoardService {
             boardParticipantRepository.save(boardParticipantSave);
         }
         if(boardParticipantInWriter==false){
-            throw new BoardHandler(ErrorStatus.WRITER_NOT_IN_BOARDPARTICIPANT);
+            throw new BoardHandler(ErrorStatus.WRITER_NOT_IN_BOARD_PARTICIPANT);
         }
        // return BoardRequestDto.toDto(boardSave);
         return boardSave.getTitle()+"게시글이 작성되었습니다."; //굳이 리턴값을 줄필요 없을듯 ???

--- a/src/main/java/gang/GNUtingBackend/mail/controller/MailController.java
+++ b/src/main/java/gang/GNUtingBackend/mail/controller/MailController.java
@@ -2,6 +2,7 @@ package gang.GNUtingBackend.mail.controller;
 
 import gang.GNUtingBackend.mail.dto.MailSendRequestDto;
 import gang.GNUtingBackend.mail.dto.MailSendResponseDto;
+import gang.GNUtingBackend.mail.dto.MailVerifyRequestDto;
 import gang.GNUtingBackend.mail.service.MailService;
 import gang.GNUtingBackend.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -32,5 +33,15 @@ public class MailController {
 
         return ResponseEntity.ok()
                 .body(apiResponse);
+    }
+
+    @PostMapping("/mail/verify")
+    @Operation(summary = "이메일 인증번호 검증 API", description = "사용자가 입력한 인증번호를 검증합니다.")
+    public ResponseEntity<ApiResponse<?>> verifyMail(@RequestBody MailVerifyRequestDto mailVerifyRequestDto) {
+        boolean isVerified = mailService.verifyNumber(mailVerifyRequestDto.getEmail(), mailVerifyRequestDto.getNumber());
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.onSuccess("인증되었습니다."));
+
     }
 }

--- a/src/main/java/gang/GNUtingBackend/mail/dto/MailVerifyRequestDto.java
+++ b/src/main/java/gang/GNUtingBackend/mail/dto/MailVerifyRequestDto.java
@@ -1,0 +1,15 @@
+package gang.GNUtingBackend.mail.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MailVerifyRequestDto {
+
+    private String email;
+    private String number;
+}

--- a/src/main/java/gang/GNUtingBackend/response/code/status/ErrorStatus.java
+++ b/src/main/java/gang/GNUtingBackend/response/code/status/ErrorStatus.java
@@ -34,7 +34,7 @@ public enum ErrorStatus implements BaseErrorCode {
     USER_NOT_AUTHORITY(HttpStatus.BAD_REQUEST,"BOARD5003","권한이 없습니다."),
     INCORRECT_NUMBER_OF_PEOPLE(HttpStatus.BAD_REQUEST,"BOARD4002", "인원수가 맞지 않습니다."),
     PAGE_NOT_FOUND(HttpStatus.BAD_REQUEST,"BOARD4003","현재 페이지 내 표시할 게시글이 없습니다. "),
-    WRITER_NOT_IN_BOARDPARTICIPANT(HttpStatus.BAD_REQUEST,"BOARD4004","작성자가 포함되어 있지 않습니다."),
+    WRITER_NOT_IN_BOARD_PARTICIPANT(HttpStatus.BAD_REQUEST,"BOARD4004","작성자가 포함되어 있지 않습니다."),
     NOT_MATCH_GENDER(HttpStatus.BAD_REQUEST,"BOARD4005","신청자의 성별이 게시물의 성별과 동일합니다"),
     LEADER_NOT_IN_APPLYUSER(HttpStatus.BAD_REQUEST,"BOARD4006","신청자(리더)가 포함되어있지 않습니다."),
 
@@ -43,7 +43,8 @@ public enum ErrorStatus implements BaseErrorCode {
     USER_NOT_APPLY(HttpStatus.BAD_REQUEST,"APPLY4002","유저가 신청하지 않았습니다"),
 
     // 메일 관련 에러
-    INVALID_MAIL_ADDRESS(HttpStatus.BAD_REQUEST, "MAIL4001", "경상국립대학교 이메일을 입력해주세요."),
+    INVALID_MAIL_ADDRESS(HttpStatus.BAD_REQUEST, "MAIL4000", "경상국립대학교 이메일을 입력해주세요."),
+    INVALID_VERIFY_NUMBER(HttpStatus.BAD_REQUEST, "MAIL4000", "인증번호가 올바르지 않습니다."),
 
     // slack 관련 에러
     CANNOT_SEND_MESSAGE(HttpStatus.INTERNAL_SERVER_ERROR, "SLACK5001", "slack으로 메세지를 보내지 못하였습니다."),

--- a/src/main/java/gang/GNUtingBackend/user/controller/UserController.java
+++ b/src/main/java/gang/GNUtingBackend/user/controller/UserController.java
@@ -9,6 +9,7 @@ import gang.GNUtingBackend.user.domain.enums.UserRole;
 import gang.GNUtingBackend.user.dto.UserDetailResponseDto;
 import gang.GNUtingBackend.user.dto.UserLoginRequestDto;
 import gang.GNUtingBackend.user.dto.UserSignupRequestDto;
+import gang.GNUtingBackend.user.dto.token.LogoutRequestDto;
 import gang.GNUtingBackend.user.dto.token.ReIssueTokenRequestDto;
 import gang.GNUtingBackend.user.dto.token.ReIssueTokenResponseDto;
 import gang.GNUtingBackend.user.dto.token.TokenResponseDto;
@@ -164,9 +165,11 @@ public class UserController {
 
     @PostMapping("/reIssueAccessToken")
     @Operation(summary = "토큰 재발급 API", description = "refresh 토큰으로 accessToken을 재발급합니다.")
-    public ResponseEntity<ApiResponse<ReIssueTokenResponseDto>> reIssueAccessToken(@RequestBody ReIssueTokenRequestDto reIssueTokenRequestDto) {
+    public ResponseEntity<ApiResponse<ReIssueTokenResponseDto>> reIssueAccessToken(@RequestHeader("Authorization") String token,
+                                                                                   @RequestBody ReIssueTokenRequestDto reIssueTokenRequestDto) {
+        String email = tokenProvider.getUserEmail(token.substring(7));
         ReIssueTokenResponseDto response = userService.reissueAccessToken(
-                reIssueTokenRequestDto.getRefreshToken());
+                reIssueTokenRequestDto.getRefreshToken(), email);
 
         ApiResponse<ReIssueTokenResponseDto> apiResponse = ApiResponse.onSuccess(response);
 
@@ -176,13 +179,16 @@ public class UserController {
 
     /**
      * 로그아웃 API
-     * @param refreshToken 로그아웃 요청에 사용된 리프레시 토큰
+     * @param token
+     * @param logoutRequestDto 로그아웃 요청에 사용된 리프레시 토큰
      * @return 로그아웃 성공 메시지
      */
     @PostMapping("/logout")
     @Operation(summary = "로그아웃 API", description = "사용자 로그아웃을 처리합니다.")
-    public ResponseEntity<ApiResponse<String>> logout(@RequestBody String refreshToken) {
-        userService.logout(refreshToken);
+    public ResponseEntity<ApiResponse<String>> logout(@RequestHeader("Authorization") String token,
+                                                      @RequestBody LogoutRequestDto logoutRequestDto) {
+        String email = tokenProvider.getUserEmail(token.substring(7));
+        userService.logout(logoutRequestDto.getRefreshToken(), email);
         return ResponseEntity.ok()
                 .body(ApiResponse.onSuccess("정상적으로 로그아웃 처리 되었습니다."));
     }

--- a/src/main/java/gang/GNUtingBackend/user/dto/token/LogoutRequestDto.java
+++ b/src/main/java/gang/GNUtingBackend/user/dto/token/LogoutRequestDto.java
@@ -1,0 +1,14 @@
+package gang.GNUtingBackend.user.dto.token;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LogoutRequestDto {
+
+    private String refreshToken;
+}

--- a/src/main/java/gang/GNUtingBackend/user/service/UserService.java
+++ b/src/main/java/gang/GNUtingBackend/user/service/UserService.java
@@ -195,16 +195,22 @@ public class UserService {
         return Token.createRefreshToken();
     }
 
+    /**
+     * 이전에 발급된 accessToken이 만료되면 새로운 accessToken 발급
+     * @param refreshToken
+     * @param email
+     * @return
+     */
     @Transactional
-    public ReIssueTokenResponseDto reissueAccessToken(String refreshToken) {
-        User user = refreshTokenService.getUserByRefreshToken(refreshToken);
-        Token token = refreshTokenService.findTokenByRefreshToken(refreshToken);
+    public ReIssueTokenResponseDto reissueAccessToken(String refreshToken, String email) {
+        User user = refreshTokenService.getUserByRefreshToken(refreshToken, email);
+        Token token = refreshTokenService.findTokenByRefreshToken(refreshToken, email);
         String oldAccessToken = token.getAccessToken();
 
         if (tokenProvider.isExpiredAccessToken(oldAccessToken)) {
             String newAccessToken = issueAccessToken(user);
             token.setAccessToken(newAccessToken);
-            refreshTokenService.updateToken(token);
+            refreshTokenService.updateToken(refreshToken, newAccessToken, token.getExpiration(), email);
             return new ReIssueTokenResponseDto(newAccessToken);
         }
         throw new TokenHandler(ErrorStatus.NOT_EXPIRED_ACCESS_TOKEN);
@@ -214,9 +220,8 @@ public class UserService {
      * 로그아웃 로직
      * @param refreshToken 로그아웃 요청한 사용자의 리프레시 토큰
      */
-    @Transactional
-    public void logout(String refreshToken) {
-        refreshTokenService.logout(refreshToken);
+    public void logout(String refreshToken, String email) {
+        refreshTokenService.logout(refreshToken, email);
     }
 
     /**

--- a/src/main/java/gang/GNUtingBackend/user/token/RefreshTokenService.java
+++ b/src/main/java/gang/GNUtingBackend/user/token/RefreshTokenService.java
@@ -21,51 +21,54 @@ public class RefreshTokenService {
     private final long expiredDate = 60 * 60 * 1000 * 24 * 14;
 
     private final UserRepository userRepository;
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private String generateKey(String email, String refreshToken) {
+        return String.format("refreshToken:%s:%s", email, refreshToken);
+    }
 
     public void saveToken(String email, String refreshToken, String accessToken) {
-        Token token = Token.builder()
-                .email(email)
-                .refreshToken(refreshToken)
-                .accessToken(accessToken)
-                .expiration(expiredDate)
-                .build();
-
-        redisTemplate.opsForValue().set(refreshToken, token, expiredDate, TimeUnit.MILLISECONDS);
+        String key = generateKey(email, refreshToken);
+        redisTemplate.opsForValue().set(key, accessToken, expiredDate, TimeUnit.MILLISECONDS);
     }
 
-    public Token findTokenByRefreshToken(String refreshToken) {
-        Token token = (Token) redisTemplate.opsForValue().get(refreshToken);
-        if (token != null) {
-            return token;
+    public Token findTokenByRefreshToken(String refreshToken, String email) {
+        String key = generateKey(email, refreshToken);
+        String accessToken = redisTemplate.opsForValue().get(key);
+        if (accessToken != null) {
+            return new Token(email, refreshToken, accessToken, expiredDate);
+        } else {
+            throw new TokenHandler(ErrorStatus.INVALID_REFRESH_TOKEN);
         }
-        throw new TokenHandler(ErrorStatus.INVALID_REFRESH_TOKEN);
     }
 
-    public User getUserByRefreshToken(String refreshToken) {
-        Token token = findTokenByRefreshToken(refreshToken);
+    public User getUserByRefreshToken(String refreshToken, String email) {
+        String key = generateKey(email, refreshToken);
+        Token token = findTokenByRefreshToken(refreshToken, email);
         if (token.getExpiration() > 0) {
-            String email = token.getEmail();
             return userRepository.findByEmail(email)
                     .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
         }
         throw new TokenHandler(ErrorStatus.INVALID_REFRESH_TOKEN);
     }
 
-    public void updateToken(Token token) {
-        redisTemplate.opsForValue().set(token.getRefreshToken(), token, token.getExpiration(), TimeUnit.MILLISECONDS);
+    public void updateToken(String refreshToken, String accessToken, long expiration, String email) {
+        String key = generateKey(email, refreshToken);
+        redisTemplate.opsForValue().set(key, accessToken, expiration, TimeUnit.MILLISECONDS);
     }
 
-    public void logout(String refreshToken) {
-        redisTemplate.delete(refreshToken);
+    public void logout(String refreshToken, String email) {
+        String key = generateKey(email, refreshToken);
+        Boolean result = redisTemplate.delete(key);
+        if (Boolean.FALSE.equals(result)) {
+            throw new TokenHandler(ErrorStatus.INVALID_REFRESH_TOKEN);
+        }
     }
 
     public void deleteUserRefreshTokens(String email) {
-        // 사용자 이메일을 기반으로 저장된 모든 Refresh Token 키를 조회
-        Set<String> refreshTokens = redisTemplate.keys("*" + email + "*");
-        if (refreshTokens != null && !refreshTokens.isEmpty()) {
-            // 조회된 모든 Refresh Token 삭제
-            redisTemplate.delete(refreshTokens);
+        Set<String> keys = redisTemplate.keys("refreshToken:" + email + ":*");
+        if (keys != null && !keys.isEmpty()) {
+            redisTemplate.delete(keys);
         }
     }
 


### PR DESCRIPTION
## feat: 이메일 인증번호 검증 API 구현, 로그아웃, 회원탈퇴, reissueAccessToken 리팩토링

- 사용자의 이메일 인증번호를 redis에 저장하고, 사용자가 입력한 인증번호와 저장된 인증번호를 비교하여 인증번호를 검증합니다.

- redis의 키 값을 수정함에 따라 기존 로그아웃, 회원탈퇴, reissueAccesToken의 로직을 리팩토링 하였습니다. 