### PR TITLE
refactor: jwt token 예외 처리 및 로직 수정

### DIFF
--- a/src/main/java/gang/GNUtingBackend/chat/domain/Chat.java
+++ b/src/main/java/gang/GNUtingBackend/chat/domain/Chat.java
@@ -1,0 +1,4 @@
+package gang.GNUtingBackend.chat.domain;
+
+public class Chat {
+}

--- a/src/main/java/gang/GNUtingBackend/config/security/SecurityConfig.java
+++ b/src/main/java/gang/GNUtingBackend/config/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package gang.GNUtingBackend.config.security;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import gang.GNUtingBackend.user.filter.JwtFilter;
 import gang.GNUtingBackend.user.token.TokenProvider;
 import java.util.Arrays;
@@ -24,6 +25,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
 
     private final TokenProvider tokenProvider;
+    private final ObjectMapper objectMapper;
 
     @Bean
     public BCryptPasswordEncoder encodePwd() {
@@ -58,7 +60,7 @@ public class SecurityConfig {
                 .anyRequest().permitAll()
 
                 .and()
-                .addFilterBefore(new JwtFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(new JwtFilter(tokenProvider, objectMapper), UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 

--- a/src/main/java/gang/GNUtingBackend/response/ApiResponse.java
+++ b/src/main/java/gang/GNUtingBackend/response/ApiResponse.java
@@ -39,4 +39,10 @@ public class ApiResponse<T> {
     public static <T> ApiResponse<T> onFailure(String code, String message, T data){
         return new ApiResponse<>(false, code, message, data);
     }
+
+    public static <T> ApiResponse<T> onFailure(String code, String message){
+        return new ApiResponse<>(false, code, message, null);
+    }
+
+
 }

--- a/src/main/java/gang/GNUtingBackend/response/code/status/ErrorStatus.java
+++ b/src/main/java/gang/GNUtingBackend/response/code/status/ErrorStatus.java
@@ -17,15 +17,15 @@ public enum ErrorStatus implements BaseErrorCode {
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
     // User 관련 에러
-    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4000", "사용자가 없습니다."),
-    NICKNAME_INPUT_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER4000", "닉네임을 입력해주세요"),
-    DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "USER4000", "이미 사용중인 닉네임입니다."),
-    USER_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "USER4000", "이미 가입된 사용자입니다."),
-    PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "USER4000", "비밀번호가 일치하지 않습니다."),
-    USER_GENDER_NOT_MATCH(HttpStatus.BAD_REQUEST, "USER4000", "사용자가 없습니다. (성별이 일치하지않거나 닉네임이 잘못됐습니다.)"),
-    INVALID_STUDENT_ID(HttpStatus.BAD_REQUEST, "USER4000", "학번은 숫자 2자리로 입력해주세요."),
-    NICKNAME_LENGTH_EXCEEDED(HttpStatus.BAD_REQUEST, "USER4000", "닉네임은 최대 10자까지 가능합니다."),
-    USER_SELF_INTRODUCTION_LENGTH_EXCEEDED(HttpStatus.BAD_REQUEST, "USER4000", "한 줄 소개는 최대 30자까지 가능합니다."),
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4000-1", "사용자가 없습니다."),
+    NICKNAME_INPUT_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER4000-2", "닉네임을 입력해주세요"),
+    DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "USER4000-3", "이미 사용중인 닉네임입니다."),
+    USER_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "USER4000-4", "이미 가입된 사용자입니다."),
+    PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "USER4000-5", "비밀번호가 일치하지 않습니다."),
+    USER_GENDER_NOT_MATCH(HttpStatus.BAD_REQUEST, "USER4000-6", "사용자가 없습니다. (성별이 일치하지않거나 닉네임이 잘못됐습니다.)"),
+    INVALID_STUDENT_ID(HttpStatus.BAD_REQUEST, "USER4000-7", "학번은 숫자 2자리로 입력해주세요."),
+    NICKNAME_LENGTH_EXCEEDED(HttpStatus.BAD_REQUEST, "USER4000-8", "닉네임은 최대 10자까지 가능합니다."),
+    USER_SELF_INTRODUCTION_LENGTH_EXCEEDED(HttpStatus.BAD_REQUEST, "USER4000-9", "한 줄 소개는 최대 30자까지 가능합니다."),
     PASSWORD_IS_NOT_VALID(HttpStatus.BAD_REQUEST,"USER4006","비밀번호를 특수문자,영문자 1개이상 포함 8~15자 이내로 작성하세요"),
 
     // Board 관련 에러
@@ -50,14 +50,14 @@ public enum ErrorStatus implements BaseErrorCode {
     CANNOT_SEND_MESSAGE(HttpStatus.INTERNAL_SERVER_ERROR, "SLACK5001", "slack으로 메세지를 보내지 못하였습니다."),
 
     // token 관련 에러
-    EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001", "Access Token이 만료되었습니다."),
-    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001", "유효하지 않은 Access Token입니다."),
-    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001", "Refresh Token이 만료되었습니다."),
-    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001", "유효하지 않은 Refresh Token입니다."),
+    EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001-1", "Access Token이 만료되었습니다."),
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001-2", "유효하지 않은 Access Token입니다."),
+    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001-3", "Refresh Token이 만료되었습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001-4", "유효하지 않은 Refresh Token입니다."),
     NOT_EXPIRED_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "TOKEN4000", "만료되지 않은 Access 토큰입니다."),
-    INVALID_JWT_SIGNATURE(HttpStatus.UNAUTHORIZED, "TOKEN4001", "잘못된 JWT 서명입니다."),
-    UNSUPPORTED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001", "지원되지 않는 JWT 토큰입니다."),
-    INVALID_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001", "JWT 토큰이 잘못되었습니다."),
+    INVALID_JWT_SIGNATURE(HttpStatus.UNAUTHORIZED, "TOKEN4001-5", "잘못된 JWT 서명입니다."),
+    UNSUPPORTED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001-6", "지원되지 않는 JWT 토큰입니다."),
+    INVALID_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001-7", "JWT 토큰이 잘못되었습니다."),
 
     // notification 관련 에러
     OVERLAP_USER_TOKEN(HttpStatus.BAD_REQUEST,"FIREBASE4000","이미 유저의 파이어베이스토큰이 저장되어 있습니다"),

--- a/src/main/java/gang/GNUtingBackend/user/controller/UserController.java
+++ b/src/main/java/gang/GNUtingBackend/user/controller/UserController.java
@@ -169,18 +169,15 @@ public class UserController {
 
     /**
      * accessToken이 만료되면 refreshToken을 통해 accessToken을 재발급한다.
-     * @param token
      * @param reIssueTokenRequestDto
      * @return
      */
     @PostMapping("/reIssueAccessToken")
     @Operation(summary = "토큰 재발급 API", description = "refresh 토큰으로 accessToken을 재발급합니다.")
     public ResponseEntity<ApiResponse<ReIssueTokenResponseDto>> reIssueAccessToken(
-            @RequestHeader("Authorization") String token,
             @RequestBody ReIssueTokenRequestDto reIssueTokenRequestDto) {
-        String email = tokenProvider.getUserEmail(token.substring(7));
         ReIssueTokenResponseDto response = userService.reissueAccessToken(
-                reIssueTokenRequestDto.getRefreshToken(), email);
+                reIssueTokenRequestDto.getRefreshToken());
 
         ApiResponse<ReIssueTokenResponseDto> apiResponse = ApiResponse.onSuccess(response);
 

--- a/src/main/java/gang/GNUtingBackend/user/service/UserService.java
+++ b/src/main/java/gang/GNUtingBackend/user/service/UserService.java
@@ -203,11 +203,11 @@ public class UserService {
      * 이전에 발급된 accessToken이 만료되면 새로운 accessToken 발급
      *
      * @param refreshToken
-     * @param email
      * @return
      */
     @Transactional
-    public ReIssueTokenResponseDto reissueAccessToken(String refreshToken, String email) {
+    public ReIssueTokenResponseDto reissueAccessToken(String refreshToken) {
+        String email = refreshTokenService.getEmailByRefreshToken(refreshToken);
         User user = refreshTokenService.getUserByRefreshToken(refreshToken, email);
         Token token = refreshTokenService.findTokenByRefreshToken(refreshToken, email);
         String oldAccessToken = token.getAccessToken();

--- a/src/main/java/gang/GNUtingBackend/user/token/RefreshTokenService.java
+++ b/src/main/java/gang/GNUtingBackend/user/token/RefreshTokenService.java
@@ -27,9 +27,15 @@ public class RefreshTokenService {
         return String.format("refreshToken:%s:%s", email, refreshToken);
     }
 
+    public void saveEmail(String email, String refreshToken) {
+        String key = "refreshToken:" + refreshToken;
+        redisTemplate.opsForValue().set(key, email, expiredDate, TimeUnit.MILLISECONDS);
+    }
+
     public void saveToken(String email, String refreshToken, String accessToken) {
         String key = generateKey(email, refreshToken);
         redisTemplate.opsForValue().set(key, accessToken, expiredDate, TimeUnit.MILLISECONDS);
+        saveEmail(email, refreshToken);
     }
 
     public Token findTokenByRefreshToken(String refreshToken, String email) {
@@ -40,6 +46,11 @@ public class RefreshTokenService {
         } else {
             throw new TokenHandler(ErrorStatus.INVALID_REFRESH_TOKEN);
         }
+    }
+
+    public String getEmailByRefreshToken(String refreshToken) {
+        String key = "refreshToken:" + refreshToken;
+        return redisTemplate.opsForValue().get(key);
     }
 
     public User getUserByRefreshToken(String refreshToken, String email) {


### PR DESCRIPTION
## jwt token 예외 처리 및 로직 수정

- 토큰이 만료되면 client에게 만료 됐다는 걸 알리기 위해 JwtFilter에 예외처리를 해주었습니다.

- AccessToken을 재발급 하는 reissueAccessToken 메서드에 파라미터를 수정하면서 전체 로직을 수정하였습니다.