### PR TITLE
refactor: 채팅방 채팅 조회 로직 수정, 채팅방 목록 조회시 자신을 제외한 채팅방 사용자들의 프로필 이미지를 가져오도록 로직 수정

### DIFF
--- a/src/main/java/gang/GNUtingBackend/chat/domain/ChatRoom.java
+++ b/src/main/java/gang/GNUtingBackend/chat/domain/ChatRoom.java
@@ -2,9 +2,7 @@ package gang.GNUtingBackend.chat.domain;
 
 import gang.GNUtingBackend.user.domain.BaseEntity;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;

--- a/src/main/java/gang/GNUtingBackend/chat/dto/ChatRoomResponseDto.java
+++ b/src/main/java/gang/GNUtingBackend/chat/dto/ChatRoomResponseDto.java
@@ -1,6 +1,5 @@
 package gang.GNUtingBackend.chat.dto;
 
-
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,4 +12,5 @@ public class ChatRoomResponseDto {
     private String title;
     private String leaderUserDepartment;
     private String applyLeaderDepartment;
+    private List<String> ChatRoomUserProfileImages;
 }

--- a/src/main/java/gang/GNUtingBackend/chat/handler/StompHandler.java
+++ b/src/main/java/gang/GNUtingBackend/chat/handler/StompHandler.java
@@ -1,6 +1,7 @@
 package gang.GNUtingBackend.chat.handler;
 
 import gang.GNUtingBackend.chat.repository.ChatRoomUserRepository;
+import gang.GNUtingBackend.exception.handler.ChatRoomHandler;
 import gang.GNUtingBackend.exception.handler.UserHandler;
 import gang.GNUtingBackend.exception.handler.WebSocketHandler;
 import gang.GNUtingBackend.response.code.status.ErrorStatus;
@@ -66,7 +67,7 @@ public class StompHandler implements ChannelInterceptor {
         Long chatRoomId = parseChatRoomIdFromPath(accessor);
         accessor.getSessionAttributes().put("chatRoomId", chatRoomId);
         chatRoomUserRepository.findByChatRoomIdAndUserEmail(chatRoomId, userEmail)
-                .orElseThrow(() -> new WebSocketHandler(ErrorStatus.NOT_FOUND_CHAT_ROOM_USER));
+                .orElseThrow(() -> new ChatRoomHandler(ErrorStatus.NOT_FOUND_CHAT_ROOM_USER));
 
         log.info("SUBSCRIBE - ChatRoomId: {} | userEmail: {}", chatRoomId, userEmail);
     }

--- a/src/main/java/gang/GNUtingBackend/chat/handler/WebSocketEventListener.java
+++ b/src/main/java/gang/GNUtingBackend/chat/handler/WebSocketEventListener.java
@@ -2,8 +2,6 @@ package gang.GNUtingBackend.chat.handler;
 
 import gang.GNUtingBackend.chat.domain.enums.MessageType;
 import gang.GNUtingBackend.chat.dto.ChatRequestDto;
-import gang.GNUtingBackend.exception.handler.WebSocketHandler;
-import gang.GNUtingBackend.response.code.status.ErrorStatus;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/gang/GNUtingBackend/chat/service/ChatRoomService.java
+++ b/src/main/java/gang/GNUtingBackend/chat/service/ChatRoomService.java
@@ -61,16 +61,26 @@ public class ChatRoomService {
      * @param email
      * @return
      */
+    @Transactional(readOnly = true)
     public List<ChatRoomResponseDto> findChatRoomsByUserEmail(String email) {
         List<ChatRoomUser> allByUserEmail = chatRoomUserRepository.findAllByUserEmail(email);
 
         return allByUserEmail.stream()
-                .map(cru -> ChatRoomResponseDto.builder()
-                        .id(cru.getChatRoom().getId())
-                        .title(cru.getChatRoom().getTitle())
-                        .leaderUserDepartment(cru.getChatRoom().getLeaderUserDepartment())
-                        .applyLeaderDepartment(cru.getChatRoom().getApplyLeaderDepartment())
-                        .build())
+                .map(cru -> {
+                    ChatRoom chatRoom = cru.getChatRoom();
+                    List<String> chatRoomUserProfileImages = chatRoom.getChatRoomUsers().stream()
+                            .filter(chatRoomUser -> !chatRoomUser.getUser().getEmail().equals(email))
+                            .map(chatRoomUser -> chatRoomUser.getUser().getProfileImage())
+                            .collect(Collectors.toList());
+
+                    return ChatRoomResponseDto.builder()
+                            .id(chatRoom.getId())
+                            .title(chatRoom.getTitle())
+                            .leaderUserDepartment(chatRoom.getLeaderUserDepartment())
+                            .applyLeaderDepartment(chatRoom.getApplyLeaderDepartment())
+                            .ChatRoomUserProfileImages(chatRoomUserProfileImages)
+                            .build();
+                })
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/gang/GNUtingBackend/exception/handler/ChatRoomUserHandler.java
+++ b/src/main/java/gang/GNUtingBackend/exception/handler/ChatRoomUserHandler.java
@@ -1,0 +1,11 @@
+package gang.GNUtingBackend.exception.handler;
+
+import gang.GNUtingBackend.exception.GeneralException;
+import gang.GNUtingBackend.response.code.BaseErrorCode;
+
+public class ChatRoomUserHandler extends GeneralException {
+
+    public ChatRoomUserHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/gang/GNUtingBackend/response/code/status/ErrorStatus.java
+++ b/src/main/java/gang/GNUtingBackend/response/code/status/ErrorStatus.java
@@ -71,12 +71,14 @@ public enum ErrorStatus implements BaseErrorCode {
     // websocket 관련 에러
     SESSION_ATTRIBUTES_IS_NULL(HttpStatus.INTERNAL_SERVER_ERROR, "WEBSOCKET5001", "session attributes가 null 입니다."),
     SESSION_ATTRIBUTE_NOT_FOUND(HttpStatus.BAD_REQUEST, "WEBSOCKET4001", "요청한 session attributes에 해당하는 값이 없습니다."),
-    NOT_FOUND_CHAT_ROOM_USER(HttpStatus.BAD_REQUEST, "WEBSOCKET4002", "채팅방에 해당 이메일을 가진 유저가 없습니다."),
     INVALID_DESTINATION(HttpStatus.BAD_REQUEST, "WEBSOCKET4003", "잘못된 경로입니다."),
 
 
     // chatRoom 관련 에러
-    CHAT_ROOM_NOT_FOUND(HttpStatus.BAD_REQUEST, "CHATROOM4001", "채팅방을 찾을 수 없습니다.");
+    CHAT_ROOM_NOT_FOUND(HttpStatus.BAD_REQUEST, "CHATROOM4001", "채팅방을 찾을 수 없습니다."),
+
+    // chatRoomUser 관련 에러
+    NOT_FOUND_CHAT_ROOM_USER(HttpStatus.BAD_REQUEST, "CHATROOMUSER4001", "채팅방에 해당 이메일을 가진 유저가 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## refactor: 채팅방 조회 로직 수정, 채팅방 목록 조회시 자신을 제외한 채팅방 사용자들의 프로필 이미지를 가져오도록 로직 수정

- 채팅방 조회 시 자신이 참여햔 채팅방에 모든 채팅을 조회하도록 합니다.

- 채팅방 목록 조회시 자신을 제외한 채팅방 사용자들의 프로필 이미지를 가져오도록 합니다.
