### PR TITLE
feat: 채팅방 생성 시 유저들 채팅방 입장 메시지 로직 수정, 채팅방 Disconnet 이후 안 읽은 메세지가 있는지 확인하는 기능 구현

### DIFF
--- a/src/main/java/gang/GNUtingBackend/chat/controller/ChatController.java
+++ b/src/main/java/gang/GNUtingBackend/chat/controller/ChatController.java
@@ -68,5 +68,13 @@ public class ChatController {
                 .body(ApiResponse.onSuccess(chatRoomService.findChatRoomsByUserEmail(email)));
     }
 
+    @GetMapping("/{chatRoomId}/hasNewMessages")
+    public ResponseEntity<?> hasNewMessages(
+            @PathVariable Long chatRoomId,
+            @RequestHeader("Authorization") String token) {
+        String email = tokenProvider.getUserEmail(token.substring(7));
 
+        return ResponseEntity.ok()
+                .body(ApiResponse.onSuccess(chatService.hasNewMessages(email, chatRoomId)));
+    }
 }

--- a/src/main/java/gang/GNUtingBackend/chat/domain/ChatRoomUser.java
+++ b/src/main/java/gang/GNUtingBackend/chat/domain/ChatRoomUser.java
@@ -2,6 +2,7 @@ package gang.GNUtingBackend.chat.domain;
 
 import gang.GNUtingBackend.user.domain.BaseEntity;
 import gang.GNUtingBackend.user.domain.User;
+import java.time.LocalDateTime;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -32,4 +33,10 @@ public class ChatRoomUser extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    private LocalDateTime lastDisconnectedTime;
+
+    public void setLastDisconnectedTime(LocalDateTime lastDisconnectedTime) {
+        this.lastDisconnectedTime = lastDisconnectedTime;
+    }
 }

--- a/src/main/java/gang/GNUtingBackend/chat/handler/WebSocketEventListener.java
+++ b/src/main/java/gang/GNUtingBackend/chat/handler/WebSocketEventListener.java
@@ -21,7 +21,6 @@ import org.springframework.web.socket.messaging.SessionSubscribeEvent;
 public class WebSocketEventListener {
 
     private static final Logger logger = LoggerFactory.getLogger(WebSocketEventListener.class);
-    private final SimpMessageSendingOperations messagingTemplate;
 
     @EventListener
     public void handleWebSocketConnectListener(SessionConnectedEvent event) {
@@ -38,8 +37,6 @@ public class WebSocketEventListener {
 
             logger.info("{}({})님이 ChatRoomId : {}를 구독하였습니다.", userNickname, userEmail, chatRoomId);
 
-            ChatRequestDto chatRequest = new ChatRequestDto(MessageType.ENTER, userNickname + "님이 채팅방에 입장했습니다.");
-            messagingTemplate.convertAndSend("/sub/chatRoom/" + chatRoomId, chatRequest);
         } catch (Exception e) { // WebSocketHandler 대신 Exception을 사용하여 모든 예외를 포착합니다.
             logger.error("구독 처리 중 예외 발생: {}", e.getMessage(), e);
             // 필요한 예외 처리 로직을 추가할 수 있습니다.
@@ -54,10 +51,6 @@ public class WebSocketEventListener {
         Long chatRoomId = safelyGetValue(accessor, "chatRoomId", Long.class);
 
         logger.info("{}({})님이 ChatRoomId : {}를 떠났습니다.", userNickname, userEmail, chatRoomId);
-
-        ChatRequestDto chatRequest = new ChatRequestDto(MessageType.LEAVE,
-                userNickname + "님이 채팅방을 떠났습니다.");
-        messagingTemplate.convertAndSend("/sub/chatRoom/" + chatRoomId, chatRequest);
     }
 
     private <T> T safelyGetValue(StompHeaderAccessor accessor, String key, Class<T> type) {

--- a/src/main/java/gang/GNUtingBackend/chat/handler/WebSocketEventListener.java
+++ b/src/main/java/gang/GNUtingBackend/chat/handler/WebSocketEventListener.java
@@ -1,16 +1,19 @@
 package gang.GNUtingBackend.chat.handler;
 
-import gang.GNUtingBackend.chat.domain.enums.MessageType;
-import gang.GNUtingBackend.chat.dto.ChatRequestDto;
+import gang.GNUtingBackend.chat.domain.ChatRoomUser;
+import gang.GNUtingBackend.chat.repository.ChatRoomUserRepository;
+import gang.GNUtingBackend.exception.handler.ChatRoomHandler;
+import gang.GNUtingBackend.response.code.status.ErrorStatus;
+import java.time.LocalDateTime;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.event.EventListener;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.socket.messaging.SessionConnectedEvent;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 import org.springframework.web.socket.messaging.SessionSubscribeEvent;
@@ -21,6 +24,7 @@ import org.springframework.web.socket.messaging.SessionSubscribeEvent;
 public class WebSocketEventListener {
 
     private static final Logger logger = LoggerFactory.getLogger(WebSocketEventListener.class);
+    private final ChatRoomUserRepository chatRoomUserRepository;
 
     @EventListener
     public void handleWebSocketConnectListener(SessionConnectedEvent event) {
@@ -43,12 +47,18 @@ public class WebSocketEventListener {
         }
     }
 
+    @Transactional
     @EventListener
     public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
         String userEmail = safelyGetValue(accessor, "userEmail", String.class);
         String userNickname = safelyGetValue(accessor, "userNickname", String.class);
         Long chatRoomId = safelyGetValue(accessor, "chatRoomId", Long.class);
+
+        ChatRoomUser chatRoomUser = chatRoomUserRepository.findByChatRoomIdAndUserEmail(chatRoomId, userEmail)
+                .orElseThrow(() -> new ChatRoomHandler(ErrorStatus.NOT_FOUND_CHAT_ROOM_USER));
+        chatRoomUser.setLastDisconnectedTime(LocalDateTime.now());
+        chatRoomUserRepository.save(chatRoomUser);
 
         logger.info("{}({})님이 ChatRoomId : {}를 떠났습니다.", userNickname, userEmail, chatRoomId);
     }

--- a/src/main/java/gang/GNUtingBackend/chat/repository/ChatRepository.java
+++ b/src/main/java/gang/GNUtingBackend/chat/repository/ChatRepository.java
@@ -1,11 +1,13 @@
 package gang.GNUtingBackend.chat.repository;
 
 import gang.GNUtingBackend.chat.domain.Chat;
-import gang.GNUtingBackend.chat.dto.ChatResponseDto;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatRepository extends JpaRepository<Chat, Long> {
 
     List<Chat> findByChatRoomId(Long chatRoomId);
+
+    Long countByChatRoomIdAndCreatedAtAfter(Long chatRoomId, LocalDateTime lastDisconnectedTime);
 }

--- a/src/main/java/gang/GNUtingBackend/chat/repository/ChatRoomUserRepository.java
+++ b/src/main/java/gang/GNUtingBackend/chat/repository/ChatRoomUserRepository.java
@@ -1,6 +1,7 @@
 package gang.GNUtingBackend.chat.repository;
 
 import gang.GNUtingBackend.chat.domain.ChatRoomUser;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,4 +14,7 @@ public interface ChatRoomUserRepository extends JpaRepository <ChatRoomUser, Lon
 
     @Query("SELECT cru FROM ChatRoomUser cru WHERE cru.user.email = :email")
     List<ChatRoomUser> findAllByUserEmail(String email);
+
+    @Query("SELECT cru.lastDisconnectedTime FROM ChatRoomUser cru WHERE cru.user.email = :email AND cru.chatRoom.id = :chatRoomId")
+    LocalDateTime findLastDisconnectedTimeByUserEmailAndChatRoomId(String email, Long chatRoomId);
 }

--- a/src/main/java/gang/GNUtingBackend/chat/service/ChatRoomService.java
+++ b/src/main/java/gang/GNUtingBackend/chat/service/ChatRoomService.java
@@ -27,6 +27,7 @@ public class ChatRoomService {
 
     /**
      * 채팅방 생성
+     *
      * @param chatMemberDto
      * @return
      */
@@ -58,7 +59,6 @@ public class ChatRoomService {
         ChatRequestDto enterMessage = new ChatRequestDto(MessageType.ENTER, enterChatRoomUsers);
         messagingTemplate.convertAndSend("/sub/chatRoom/" + chatRoom.getId(), enterMessage);
 
-
         return ChatRoomResponseDto.builder()
                 .id(chatRoom.getId())
                 .title(chatRoom.getTitle())
@@ -69,6 +69,7 @@ public class ChatRoomService {
 
     /**
      * 해당 이메일을 가진 유저가 참여중인 모든 채팅방을 조회
+     *
      * @param email
      * @return
      */

--- a/src/main/java/gang/GNUtingBackend/chat/service/ChatRoomService.java
+++ b/src/main/java/gang/GNUtingBackend/chat/service/ChatRoomService.java
@@ -3,14 +3,16 @@ package gang.GNUtingBackend.chat.service;
 import gang.GNUtingBackend.board.dto.ChatMemberDto;
 import gang.GNUtingBackend.chat.domain.ChatRoom;
 import gang.GNUtingBackend.chat.domain.ChatRoomUser;
+import gang.GNUtingBackend.chat.domain.enums.MessageType;
+import gang.GNUtingBackend.chat.dto.ChatRequestDto;
 import gang.GNUtingBackend.chat.dto.ChatRoomResponseDto;
-import gang.GNUtingBackend.chat.dto.ChatRoomUserDto;
 import gang.GNUtingBackend.chat.repository.ChatRoomRepository;
 import gang.GNUtingBackend.chat.repository.ChatRoomUserRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +23,7 @@ public class ChatRoomService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatRoomUserService chatRoomUserService;
     private final ChatRoomUserRepository chatRoomUserRepository;
+    private final SimpMessageSendingOperations messagingTemplate;
 
     /**
      * 채팅방 생성
@@ -47,6 +50,14 @@ public class ChatRoomService {
 
         chatRoom.setChatRoomUsers(chatRoomUsers);
         chatRoomRepository.save(chatRoom);
+
+        String enterChatRoomUsers = chatRoomUsers.stream()
+                .map(chatRoomUser -> chatRoomUser.getUser().getNickname())
+                .collect(Collectors.joining("님, ", "", "님이 채팅방에 입장하셨습니다."));
+
+        ChatRequestDto enterMessage = new ChatRequestDto(MessageType.ENTER, enterChatRoomUsers);
+        messagingTemplate.convertAndSend("/sub/chatRoom/" + chatRoom.getId(), enterMessage);
+
 
         return ChatRoomResponseDto.builder()
                 .id(chatRoom.getId())

--- a/src/main/java/gang/GNUtingBackend/chat/service/ChatService.java
+++ b/src/main/java/gang/GNUtingBackend/chat/service/ChatService.java
@@ -12,6 +12,7 @@ import gang.GNUtingBackend.exception.handler.UserHandler;
 import gang.GNUtingBackend.response.code.status.ErrorStatus;
 import gang.GNUtingBackend.user.domain.User;
 import gang.GNUtingBackend.user.repository.UserRepository;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -86,5 +87,12 @@ public class ChatService {
                     .createdDate(chat.getCreateDate())
                     .build();
         }).collect(Collectors.toList());
+    }
+
+    public boolean hasNewMessages(String email, Long chatRoomId) {
+        LocalDateTime lastDisconnectedTime = chatRoomUserRepository.findLastDisconnectedTimeByUserEmailAndChatRoomId(email, chatRoomId);
+        Long newMessagesCount = chatRepository.countByChatRoomIdAndCreatedAtAfter(chatRoomId, lastDisconnectedTime);
+
+        return newMessagesCount > 0;
     }
 }


### PR DESCRIPTION
## feat: 채팅방 생성 시 유저들 채팅방 입장 메시지 로직 수정, 채팅방 Disconnet 이후 안 읽은 메세지가 있는지 확인하는 기능 구현

- 기존 EventListener를 사용하여 Subscribe시 자동으로 입장 메세지를 보내던 방식에서 채팅방 생성시 1번만 보내도록 로직 수정
   ex) A님, B님, C님이 채팅방에 입장하셨습니다.

- 채팅방에 안 읽은 메세지가 있는지 확인하기 위하여 Disconnect한 시간을 받아서 Disconnet한 이후에 생성된 메세지가 있다면
true, 없다면 false를 반환하도록 구현하였습니다.