### PR TITLE
fix: 채팅방 목록 조회시 각 채팅방에 hasNewMessage가 있는지 확인하는 상태값 추가

### DIFF
--- a/src/main/java/gang/GNUtingBackend/chat/controller/ChatController.java
+++ b/src/main/java/gang/GNUtingBackend/chat/controller/ChatController.java
@@ -68,14 +68,4 @@ public class ChatController {
                 .body(ApiResponse.onSuccess(chatRoomService.findChatRoomsByUserEmail(email)));
     }
 
-    @GetMapping("/{chatRoomId}/hasNewMessages")
-    @Operation(summary = "안 읽은 메시지 확인 API", description = "채팅방에 안 읽은 메세지가 있는지 확인합니다.")
-    public ResponseEntity<?> hasNewMessages(
-            @PathVariable Long chatRoomId,
-            @RequestHeader("Authorization") String token) {
-        String email = tokenProvider.getUserEmail(token.substring(7));
-
-        return ResponseEntity.ok()
-                .body(ApiResponse.onSuccess(chatService.hasNewMessages(email, chatRoomId)));
-    }
 }

--- a/src/main/java/gang/GNUtingBackend/chat/dto/ChatRoomResponseDto.java
+++ b/src/main/java/gang/GNUtingBackend/chat/dto/ChatRoomResponseDto.java
@@ -13,4 +13,5 @@ public class ChatRoomResponseDto {
     private String leaderUserDepartment;
     private String applyLeaderDepartment;
     private List<String> ChatRoomUserProfileImages;
+    private boolean hasNewMessage;
 }

--- a/src/main/java/gang/GNUtingBackend/chat/service/ChatRoomService.java
+++ b/src/main/java/gang/GNUtingBackend/chat/service/ChatRoomService.java
@@ -24,6 +24,7 @@ public class ChatRoomService {
     private final ChatRoomUserService chatRoomUserService;
     private final ChatRoomUserRepository chatRoomUserRepository;
     private final SimpMessageSendingOperations messagingTemplate;
+    private final ChatService chatService;
 
     /**
      * 채팅방 생성
@@ -85,12 +86,15 @@ public class ChatRoomService {
                             .map(chatRoomUser -> chatRoomUser.getUser().getProfileImage())
                             .collect(Collectors.toList());
 
+                    boolean hasNewMessage = chatService.hasNewMessages(email, chatRoom.getId());
+
                     return ChatRoomResponseDto.builder()
                             .id(chatRoom.getId())
                             .title(chatRoom.getTitle())
                             .leaderUserDepartment(chatRoom.getLeaderUserDepartment())
                             .applyLeaderDepartment(chatRoom.getApplyLeaderDepartment())
                             .ChatRoomUserProfileImages(chatRoomUserProfileImages)
+                            .hasNewMessage(hasNewMessage)
                             .build();
                 })
                 .collect(Collectors.toList());


### PR DESCRIPTION
## fix: 채팅방 목록 조회시 각 채팅방에 hasNewMessage가 있는지 확인하는 상태값 추가

- 기존에 새로운 안 읽은 메시지가 있는지 각 채팅방 별로 각각 확인해야 했는데, 채팅방 목록 조회시 새로운 안 읽은 메시지가 있는지 확인할 수 있는 상태값을 추가하여 채팅방 목록 조회만으로 확인할 수 있도록 로직을 수정하였습니다.